### PR TITLE
OSD-10226 Add cluster ID and support viper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/kubectl v0.23.3
+	github.com/spf13/viper v1.10.1
 )
 
 replace k8s.io/kubectl => k8s.io/kubectl v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.11.0 h1:Hw/G8TtRvOElqxVIhBzXciiSTbapq8hZ2XKZsXk5ZCE=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
+github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.8.0 h1:OJtKBtEjboEZvG6AOUdh4Z1Zbyu0WcxQ0qatRrZHTVU=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
@@ -865,6 +866,7 @@ github.com/ryanuber/columnize v2.1.0+incompatible h1:j1Wcmh8OrK4Q7GXY+V7SVSY8nUW
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0 h1:TV5DVog+pihN4Rr0rN1IClv4ePpkzdg9sPrw7WDofZ8=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
+github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -915,6 +917,8 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.10.0 h1:mXH0UwHS4D2HwWZa75im4xIQynLfblmWV7qcWpfv0yk=
 github.com/spf13/viper v1.10.0/go.mod h1:SoyBPwAtKDzypXNDFKN5kzH7ppppbGZtls1UpIy5AsM=
+github.com/spf13/viper v1.10.1 h1:nuJZuYpG7gTj/XqiUwg8bA0cp1+M2mC3J4g5luUYBKk=
+github.com/spf13/viper v1.10.1/go.mod h1:IGlFPqhNAPKRxohIzWpI5QEy4kuI7tcl5WvR+8qy1rU=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1262,6 +1266,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1390,6 +1395,7 @@ google.golang.org/api v0.59.0/go.mod h1:sT2boj7M9YJxZzgeZqXogmhfmRWDtPzT31xkieUb
 google.golang.org/api v0.61.0/go.mod h1:xQRti5UdCmoCEqFxcz93fTl338AVqDgyaDRuOZ3hg9I=
 google.golang.org/api v0.62.0 h1:PhGymJMXfGBzc4lBRmrx9+1w4w2wEzURHNGF/sD/xGc=
 google.golang.org/api v0.62.0/go.mod h1:dKmwPCydfsad4qCH08MSdgWjfHOyfpd4VtDGgRFdavw=
+google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1492,6 +1498,7 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -96,7 +96,7 @@ func NewServeCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&o.ocmURL, config.OcmURL, "", "", "OCM URL")
 	cmd.Flags().StringVarP(&o.services, config.Services, "", "", "OCM service name")
 	cmd.Flags().StringVarP(&o.accessToken, config.AccessToken, "t", "", "Access token for OCM")
-	cmd.Flags().StringVarP(&o.clusterID, config.ClusterID, "i", "", "Cluster ID")
+	cmd.Flags().StringVarP(&o.clusterID, config.ClusterID, "c", "", "Cluster ID")
 	cmd.PersistentFlags().BoolVarP(&o.debug, config.Debug, "d", false, "Debug mode enable")
 	viper.BindPFlags(cmd.Flags())
 

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -8,10 +8,12 @@ import (
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	"github.com/openshift/ocm-agent/pkg/config"
 	"github.com/openshift/ocm-agent/pkg/healthcheck"
 	"github.com/openshift/ocm-agent/pkg/metrics"
 	"github.com/openshift/ocm-agent/pkg/webhookreceiver"
@@ -42,6 +44,7 @@ type serveOptions struct {
 	accessToken string
 	services    string
 	ocmURL      string
+	clusterID   string
 	debug       bool
 }
 
@@ -56,23 +59,19 @@ var (
 
 	serviceExample = templates.Examples(`
 	# Start the OCM agent server
-	ocm-agent serve --access-token "$TOKEN" --services "$SERVICE" --ocm-url "https://sample.example.com"
+	ocm-agent serve --access-token "$TOKEN" --services "$SERVICE" --ocm-url "https://sample.example.com" --cluster-id abcd-1234
 
 	# Start the OCM agent server by accepting token from a file (value starting with '@' is considered a file)
-	ocm-agent serve -t @tokenfile --services "$SERVICE" --ocm-url @urlfile
+	ocm-agent serve -t @tokenfile --services "$SERVICE" --ocm-url @urlfile --cluster-id @clusteridfile
 
 	# Start the OCM agent server in debug mode
-	ocm-agent serve -t @tokenfile --services "$SERVICE" --ocm-url @urlfile --debug
+	ocm-agent serve -t @tokenfile --services "$SERVICE" --ocm-url @urlfile --cluster-id @clusteridfile --debug
 	`)
 )
 
 const (
-	servicePort         int    = 8081
-	metricsPort         int    = 8383
-	accessTokenFlagName string = "access-token"
-	servicesFlagName    string = "services"
-	ocmURLFlagName      string = "ocm-url"
-	debugFlagName       string = "debug"
+	servicePort int = 8081
+	metricsPort int = 8383
 )
 
 func NewServeOptions() *serveOptions {
@@ -94,14 +93,17 @@ func NewServeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.ocmURL, ocmURLFlagName, "", "", "OCM URL")
-	cmd.Flags().StringVarP(&o.services, servicesFlagName, "", "", "OCM service name")
-	cmd.Flags().StringVarP(&o.accessToken, accessTokenFlagName, "t", "", "Access token for OCM")
-	cmd.PersistentFlags().BoolVarP(&o.debug, debugFlagName, "d", false, "Debug mode enable")
+	cmd.Flags().StringVarP(&o.ocmURL, config.OcmURL, "", "", "OCM URL")
+	cmd.Flags().StringVarP(&o.services, config.Services, "", "", "OCM service name")
+	cmd.Flags().StringVarP(&o.accessToken, config.AccessToken, "t", "", "Access token for OCM")
+	cmd.Flags().StringVarP(&o.clusterID, config.ClusterID, "i", "", "Cluster ID")
+	cmd.PersistentFlags().BoolVarP(&o.debug, config.Debug, "d", false, "Debug mode enable")
+	viper.BindPFlags(cmd.Flags())
 
-	_ = cmd.MarkFlagRequired(ocmURLFlagName)
-	_ = cmd.MarkFlagRequired(servicesFlagName)
-	_ = cmd.MarkFlagRequired(accessTokenFlagName)
+	_ = cmd.MarkFlagRequired(config.OcmURL)
+	_ = cmd.MarkFlagRequired(config.Services)
+	_ = cmd.MarkFlagRequired(config.AccessToken)
+	_ = cmd.MarkFlagRequired(config.ClusterID)
 
 	return cmd
 }
@@ -110,7 +112,7 @@ func NewServeCmd() *cobra.Command {
 func (o *serveOptions) Complete(cmd *cobra.Command, args []string) error {
 
 	// ReadFlagsFromFile would read the values of flags from files (if any)
-	err := ReadFlagsFromFile(cmd, accessTokenFlagName, servicesFlagName, ocmURLFlagName)
+	err := ReadFlagsFromFile(cmd, config.AccessToken, config.Services, config.OcmURL, config.ClusterID)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,14 @@
+package config
+
+const (
+	// AccessToken represents the Auth Access Token used for OCM communications
+	AccessToken string = "access-token"
+	// Services represents the list of OCM service APIs that OCM Agent will proxy
+	Services string = "services"
+	// OcmURL represents the base URL hosting the OCM API
+	OcmURL string = "ocm-url"
+	// Debug represents whether debug behaviours will be enabled
+	Debug string = "debug"
+	// ClusterID represents the ID of the cluster used for OCM notifications
+	ClusterID string = "cluster-id"
+)


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
OCM Agent needs to know the cluster ID; it's currently getting that injected into the ConfigMap used to supply config to the pod; now we need to make the agent aware that it has to read that config.

Additionally, `viper` has been introduced to enable easier retrieval of app configuration items, this will make subsequent tickets a lot easier to deal with when they need to access the application's config. eg.

```
viper.Get(config.SomeConfigKey)
```

### Which Jira/Github issue(s) this PR fixes?

[OSD-10226](https://issues.redhat.com/browse/OSD-10226)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

