### PR TITLE
[OSD-10225] handle the service log sending for resolved alerts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift-online/ocm-cli v0.1.62
 	github.com/openshift-online/ocm-sdk-go v0.1.242
-	github.com/openshift/ocm-agent-operator v0.0.0-20220316071606-afd26cc5ca68
+	github.com/openshift/ocm-agent-operator v0.0.0-20220321075240-c97bfe2ba8ea
 	github.com/prometheus/alertmanager v0.23.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1124,8 +1124,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.242 h1:fesCAv8tg2gcVAV1aKwCoQrkRmDq+
 github.com/openshift-online/ocm-sdk-go v0.1.242/go.mod h1:nHYjrmvR9L7KSRZukysau62iEHKJOQYFhlceqaVAV1Y=
 github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
 github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/ocm-agent-operator v0.0.0-20220316071606-afd26cc5ca68 h1:FqYpwnYsrk0MPBw4gxgfA8CS/0T03y4zNVkpvotmIr8=
-github.com/openshift/ocm-agent-operator v0.0.0-20220316071606-afd26cc5ca68/go.mod h1:ZwZI7wGFEmXT6bkoHfdNivUn8r5nG86g9+GeBqjIjz0=
+github.com/openshift/ocm-agent-operator v0.0.0-20220321075240-c97bfe2ba8ea h1:nJ6pRw2bHXQmE0ym5jYzm/PWATHDGF9RTDdUPX54oVY=
+github.com/openshift/ocm-agent-operator v0.0.0-20220321075240-c97bfe2ba8ea/go.mod h1:ZwZI7wGFEmXT6bkoHfdNivUn8r5nG86g9+GeBqjIjz0=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
 github.com/openshift/rosa v1.1.7/go.mod h1:Ap4vfflxHXfzY0MIt1l9dckwG+DkPUDc/vv1mk1cSCQ=

--- a/pkg/handlers/webhookreceiver.go
+++ b/pkg/handlers/webhookreceiver.go
@@ -34,6 +34,9 @@ const (
 	LogFieldAlert               = "alert"
 	LogFieldIsFiring            = "is_firing"
 	LogFieldManagedNotification = "managed_notification_cr"
+
+	ServiceLogActivePrefix  = "Issue Notification"
+	ServiceLogResolvePrefix = "Issue Resolution"
 )
 
 type WebhookReceiverHandler struct {
@@ -233,10 +236,13 @@ func (h *WebhookReceiverHandler) sendServiceLog(n *oav1alpha1.Notification, firi
 		Summary:      n.Summary,
 		InternalOnly: false,
 	}
+	// Use different Summary and Description for firing and resolved status for an alert
 	if firing {
 		sl.Description = n.ActiveDesc
+		sl.Summary = ServiceLogActivePrefix + ": " + n.Summary
 	} else {
 		sl.Description = n.ResolvedDesc
+		sl.Summary = ServiceLogResolvePrefix + ": " + n.Summary
 	}
 	slAsBytes, err := json.Marshal(sl)
 	if err != nil {

--- a/pkg/handlers/webhookreceiver_test.go
+++ b/pkg/handlers/webhookreceiver_test.go
@@ -186,12 +186,12 @@ var _ = Describe("Webhook Handlers", func() {
 	Context("When processing an alert", func() {
 		It("will check if the alert is valid or not without name", func() {
 			delete(testAlert.Labels, "alertname")
-			err := webhookReceiverHandler.processAlert(testconst.TestAlert, testconst.TestManagedNotificationList)
+			err := webhookReceiverHandler.processAlert(testconst.TestAlert, testconst.TestManagedNotificationList, true)
 			Expect(err).ToNot(BeNil())
 		})
 		It("will check if the alert can be mapped to existing notification template definition or not", func() {
 			delete(testAlert.Labels, "managed_notification_template")
-			err := webhookReceiverHandler.processAlert(testAlert, testconst.TestManagedNotificationList)
+			err := webhookReceiverHandler.processAlert(testAlert, testconst.TestManagedNotificationList, true)
 			Expect(err).ToNot(BeNil())
 		})
 	})


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
The alertmanager webhook receiver should be able to handle both the alerting and resolved alerts
And update the status correspondingly

### Which Jira/Github issue(s) this PR fixes?

Fixes #[OSD-10225](https://issues.redhat.com/browse/OSD-10225)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

