### PR TITLE
OSD-10122 Add SelectorSyncSet template

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -1,0 +1,46 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: selectorsyncset-template
+objects:
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: "true"
+    name: ocm-agent-resources
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: "true"
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: OcmAgent
+      metadata:
+        name: ocmagent
+        namespace: openshift-ocm-agent-operator
+      spec:
+        agentConfig:
+          ocmBaseUrl: ${OCM_BASE_URL}
+          services:
+          - service_logs
+        ocmAgentConfig: ocm-agent-config
+        ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        replicas: 1
+        tokenSecret: ocm-access-token
+  status: {}
+parameters:
+- name: IMAGE_TAG
+  required: true
+- name: REPO_NAME
+  required: true
+  value: ocm-agent
+- name: REGISTRY_IMG
+  required: true
+- name: IMAGE_DIGEST
+  required: true


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Adds a SelectorSyncSet template required if we want to onboard `ocm-agent` promotions into `app-interface`

### Which Jira/Github issue(s) this PR fixes?
[OSD-10122](https://issues.redhat.com/browse/OSD-10122)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

