### PR TITLE
OSD-10122 Fix the SSS template

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -44,3 +44,5 @@ parameters:
   required: true
 - name: IMAGE_DIGEST
   required: true
+- name: OCM_BASE_URL
+  required: true


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The `SelectorSyncSet` template needs to define `OCM_BASE_URL` as a parameter in order for it to be replaced.

