### PR TITLE
More understandable formatting of alert data in logs

### DIFF
--- a/pkg/handlers/webhookreceiver.go
+++ b/pkg/handlers/webhookreceiver.go
@@ -109,7 +109,7 @@ func (h *WebhookReceiverHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *WebhookReceiverHandler) processAMReceiver(d AMReceiverData, ctx context.Context) *AMReceiverResponse {
-	log.WithField("AMReceiverData", d).Info("Process alert data")
+	log.WithField("AMReceiverData", fmt.Sprintf("%+v", d)).Info("Process alert data")
 
 	// Let's get all ManagedNotifications in the
 	mnl := &oav1alpha1.ManagedNotificationList{}
@@ -146,14 +146,14 @@ func (h *WebhookReceiverHandler) processAMReceiver(d AMReceiverData, ctx context
 func (h *WebhookReceiverHandler) processAlert(alert template.Alert, mnl *oav1alpha1.ManagedNotificationList, firing bool) error {
 	// Should this alert be handled?
 	if !isValidAlert(alert) {
-		log.WithField(LogFieldAlert, alert).Info("alert does not meet valid criteria")
+		log.WithField(LogFieldAlert, fmt.Sprintf("%+v", alert)).Info("alert does not meet valid criteria")
 		return fmt.Errorf("alert does not meet valid criteria")
 	}
 
 	// Can the alert be mapped to an existing notification definition?
 	notification, managedNotifications, err := getNotification(alert.Labels[AMLabelTemplateName], mnl)
 	if err != nil {
-		log.WithError(err).WithField(LogFieldAlert, alert).Warning("an alert fired with no associated notification template definition")
+		log.WithError(err).WithField(LogFieldAlert, fmt.Sprintf("%+v", alert)).Warning("an alert fired with no associated notification template definition")
 		return err
 	}
 


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
Minor change. Improves the formatting of the alert data by ensuring that the struct's fieldnames are specified. It's not perfect, but it makes the log slightly more interpretable to know what fields mean what.

Goes from this:
```
alert="{firing map[alertname:AnotherWatchdogManagedNotificationSRE alertstate:firing namespace:openshift-monitoring openshift_io_alert_source:platform prometheus:openshift-monitoring/k8s send_managed_notification:true severity:info] map[description:test] 2022-03-13 04:45:16 +0000 UTC 0001-01-01 00:00:00 +0000 UTC https://blahblah }"
```

to this:

```
alert="{Status:firing Labels:map[alertname:AnotherWatchdogManagedNotificationSRE alertstate:firing namespace:openshift-monitoring openshift_io_alert_source:platform prometheus:openshift-monitoring/k8s send_managed_notification:true severity:info] Annotations:map[description:test] StartsAt:2022-03-13 04:45:16 +0000 UTC EndsAt:000
1-01-01 00:00:00 +0000 UTC GeneratorURL:https://blahblah Fingerprint:}"
```
