### PR TITLE
Changing image to ubi-micro to address CVE

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-218
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.5-833
 
 LABEL io.openshift.managed.name="ocm-agent" \
   io.openshift.managed.description="Agent to interact with OCM on managed clusters"


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
This PR updates the base docker image from `ubi-minimal` to `ubi-micro` such that the number of CVE reported by Clair security scan in Quay reports no/minimal vulnerabilities.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [OSD-10499](https://issues.redhat.com/browse/OSD-10499)

### Special notes for your reviewer:
- Update to latest `ubi-minimal` image version [8.5-240](https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?container-tabs=overview) did not work and it still had 2 CVEs open.
- Thus, the base image was changed to `ubi-micro` with latest version [8.5-833](https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a?container-tabs=overview). The repo image with this image showed GREEN health as seen in [image](https://quay.io/repository/travi/ocm-agent/manifest/sha256:cb22ae2ef8dda5445cc4b0b341ac868b76619ebe5e8b77bfc36ac42e9b7de0e9?tab=vulnerabilities).
- To just confirm if the change hasn't broken anything, created test managednotification to see if ocm-agent is able to send servicelog as expected and successfully got mail for it. Thus the functionality remains to be same as desired.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster

