### PR TITLE
OSD-11456 enable gosec linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+run:
+  deadline: 30m
+  concurrency: 1
+  modules-download-mode: readonly
+linters:
+  enable:
+    - gosec
+  disable:
+    - depguard
+    - gochecknoglobals
+    - gochecknoinits
+    - lll


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Enables gosec linting for ocm agent.
`golangci-lint` will include a `.golangci.yml` file if it exists in the repository.
This just adds that file and enables gosec in our existing lint check.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-11459](https://issues.redhat.com//browse/OSD-11459)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

