### PR TITLE
Refactoring logging to move to separate package

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	DebugLogLevel = logrus.DebugLevel
+)
+
+// NewLogger initializes logging with Info level logging as default
+func NewLogger() (logger *logrus.Logger) {
+	logger = &logrus.Logger{
+		Out:       os.Stderr,
+		Formatter: new(logrus.TextFormatter),
+		Level:     logrus.InfoLevel,
+	}
+	logger.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		PadLevelText:  false,
+	})
+	return logger
+}


### PR DESCRIPTION
### What type of PR is this?
_(refactor)_

### What this PR does / why we need it?
This PR refactors logging in the `serve.go` file such that it imports logging configuration from a separate package called `logging`.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [OSD-10012](https://issues.redhat.com/browse/OSD-10012)

### Special notes for your reviewer:
* For now, only serve.go has been considered for refactoring.
* The default log level is maintained to be `Info` and is set to `Debug` level if the CLI passes `-d true`. Both options work as expected.

### Pre-checks (if applicable):
- [x] Tested latest changes locally.

