### PR TITLE
Enable FIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ EXTRA_DEPS := $(find $(CURDIR)/build -type f -print) Makefile
 unexport GOFLAGS
 GOOS?=linux
 GOARCH?=amd64
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOFLAGS=
 
-GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}" -tags="fips_enabled"
 
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 SRC_CONTAINER_TRANSPORT ?= $(if $(findstring podman,$(CONTAINER_ENGINE)),containers-storage,docker-daemon)

--- a/cmd/ocm-agent/fips.go
+++ b/cmd/ocm-agent/fips.go
@@ -1,0 +1,16 @@
+//go:build fips_enabled
+// +build fips_enabled
+
+// BOILERPLATE GENERATED -- DO NOT EDIT
+// Run 'make ensure-fips' to regenerate
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Ensure that `ocm-agent` runs with FIPS enabled so that it is consistent with other OSD operators.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

