### PR TITLE
CGO_ENABLED=1 to enable FIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EXTRA_DEPS := $(find $(CURDIR)/build -type f -print) Makefile
 unexport GOFLAGS
 GOOS?=linux
 GOARCH?=amd64
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOEXPERIMENT=boringcrypto GOFLAGS=
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOFLAGS=
 
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}" -tags="fips_enabled"
 


### PR DESCRIPTION
### What type of PR is this?
Feature


### What this PR does / why we need it?
MCVW must be built with CGO_ENABLED=1 (and based on ubi-minimal) to be FIPS compliant

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17665

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

