### PR TITLE
Make services CLI flag a list

### DIFF
--- a/pkg/cli/serve/config.go
+++ b/pkg/cli/serve/config.go
@@ -11,29 +11,64 @@ import (
 // ReadFlagsFromFile checks for '@' prefix, if found try to read value from file.
 func ReadFlagsFromFile(cmd *cobra.Command, names ...string) error {
 	for _, name := range names {
-		value, err := cmd.Flags().GetString(name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to fetch value for key %s\n", name)
-			os.Exit(1)
-		}
-		if strings.HasPrefix(value, "@") {
+		flag := cmd.Flags().Lookup(name)
 
-			value = value[1:]
-			data, err := os.ReadFile(value)
+		switch flag.Value.Type() {
+		case "stringSlice":
+			values, err := cmd.Flags().GetStringSlice(name)
 			if err != nil {
-				return fmt.Errorf(
-					"can't read value of flag '%s' from file '%s': %w",
-					name, value, err,
-				)
-			}
-			value = strings.TrimSpace(string(data))
-
-			err = cmd.Flags().Set(name, value)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to set value for key %s\n", name)
+				fmt.Fprintf(os.Stderr, "unable to fetch value for key %s\n", name)
 				os.Exit(1)
+			}
+
+			if len(values) > 1 {
+				fmt.Fprintf(os.Stderr, "Must only specify one value when reading a string slice from file")
+				os.Exit(1)
+			}
+
+			if strings.HasPrefix(values[0], "@") {
+				// Remove @ from start of the first word in string slice
+				values[0] = values[0][1:]
+				data, err := os.ReadFile(values[0])
+				if err != nil {
+					return fmt.Errorf(
+						"can't read value of flag '%s' from file '%s': %w",
+						name, values, err,
+					)
+				}
+
+				dataString := strings.TrimSpace(string(data))
+				err = cmd.Flags().Set(name, dataString)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "unable to set value for key %s\n", name)
+					os.Exit(1)
+				}
+			}
+		case "string":
+			value, err := cmd.Flags().GetString(name)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "unable to fetch value for key %s\n", name)
+				os.Exit(1)
+			}
+			if strings.HasPrefix(value, "@") {
+				value = value[1:]
+				data, err := os.ReadFile(value)
+				if err != nil {
+					return fmt.Errorf(
+						"can't read value of flag '%s' from file '%s': %w",
+						name, value, err,
+					)
+				}
+				value = strings.TrimSpace(string(data))
+
+				err = cmd.Flags().Set(name, value)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "unable to set value for key %s\n", name)
+					os.Exit(1)
+				}
 			}
 		}
 	}
+
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,12 +9,14 @@ const (
 	OcmURL string = "ocm-url"
 	// Debug represents whether debug behaviours will be enabled
 	Debug string = "debug"
-	// ClusterID represents the ID of the cluster used for OCM notifications
-	ClusterID string = "cluster-id"
+	// ExternalClusterID represents the ID of the cluster used for OCM notifications
+	ExternalClusterID string = "cluster-id"
 	// FleetMode represents if ocm-agent is going to run in default OSD/ROSA mode or HyperShift mode
 	FleetMode string = "fleet-mode"
 	// OCMClientID represents the OCM Client ID that will be used for testing fleet-mode run
 	OCMClientID string = "ocm-client-id"
 	// OCMClientSecret represents the OCM Client ID that will be used for testing fleet-mode run
 	OCMClientSecret string = "ocm-client-secret" //#nosec G101 -- This is a false positive
+
+	ServiceLogService string = "service_logs"
 )

--- a/pkg/handlers/webhookreceiver.go
+++ b/pkg/handlers/webhookreceiver.go
@@ -147,7 +147,7 @@ func (h *WebhookReceiverHandler) processAlert(alert template.Alert, mnl *oav1alp
 	}
 	// Send the servicelog for the alert
 	log.WithFields(log.Fields{LogFieldNotificationName: notification.Name}).Info("will send servicelog for notification")
-	err = h.ocm.SendServiceLog(notification.Summary, notification.ActiveDesc, notification.ResolvedDesc, viper.GetString(config.ClusterID), notification.Severity, notification.LogType, notification.References, firing)
+	err = h.ocm.SendServiceLog(notification.Summary, notification.ActiveDesc, notification.ResolvedDesc, viper.GetString(config.ExternalClusterID), notification.Severity, notification.LogType, notification.References, firing)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{LogFieldNotificationName: notification.Name, LogFieldIsFiring: true}).Error("unable to send a notification")
 		metrics.SetResponseMetricFailure("service_logs")


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_


### What this PR does / why we need it?
Allows users to pass in multiple services into ocm-agent - instead of just 'service_logs'.
I.e.
`ocm agent serve --services="service_logs,clusters"`

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

