### PR TITLE
OSD-19689: implementing a place holder feature for notifications

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,6 +22,7 @@ OCM Agent are managed by [OCM Agent operator](https://github.com/openshift/ocm-a
 |ocm_agent_request_failure|Gauge|Indicates that OCM Agent could not successfully process a request|
 |ocm_agent_response_failure|Gauge|Indicates that the call to the OCM service endpoint failed|
 |ocm_agent_service_log_sent|Counter|A count of service log sent based on managedNotification template for the current session|
+|ocm_agent_failed_service_logs_total|Counter|A count of service logs which failed to be sent. This includes service logs which failed to be formatted.|
 |ocm_agent_service_log_sent_total|Gauge|A total number of service log being sent based on managedNotification template|
 
 ## Metrics reset

--- a/pkg/consts/test/test.go
+++ b/pkg/consts/test/test.go
@@ -26,9 +26,9 @@ var (
 	TestHostedClusterID  = "test-hosted-cluster-id"
 	TestNotification     = ocmagentv1alpha1.Notification{
 		Name:         TestNotificationName,
-		Summary:      "test-summary",
-		ActiveDesc:   "test-active-desc",
-		ResolvedDesc: "test-resolved-desc",
+		Summary:      "test-summary [namespace: '${namespace}']",
+		ActiveDesc:   "test-active-desc [description: '${description}', overriden-key: '${overriden-key}', recursive-key: '${recursive-key}']",
+		ResolvedDesc: "test-resolved-desc [description: '${description}', overriden-key: '${overriden-key}']",
 		Severity:     "test-severity",
 		ResendWait:   1,
 		LogType:      "test-type",
@@ -37,6 +37,10 @@ var (
 			"https://another.great.com/resource",
 		},
 	}
+	ServiceLogSummary               = "test-summary [namespace: 'openshift-monitoring']"
+	ServiceLogActiveDesc            = "test-active-desc [description: 'alert-desc', overriden-key: 'label-value', recursive-key: '_${recursive-key}_']"
+	ServiceLogResolvedDesc          = "test-resolved-desc [description: 'alert-desc', overriden-key: 'label-value']"
+	ServiceLogFleetDesc             = "test-notification [description: 'alert-desc', overriden-key: 'label-value']"
 	NotificationWithoutResolvedBody = ocmagentv1alpha1.Notification{
 		Name:       TestNotificationName,
 		Summary:    "test-summary",
@@ -95,8 +99,8 @@ var (
 func NewFleetNotification() ocmagentv1alpha1.FleetNotification {
 	return ocmagentv1alpha1.FleetNotification{
 		Name:                TestNotificationName,
-		Summary:             "test-summary",
-		NotificationMessage: "test-notification",
+		Summary:             "test-summary [namespace: '${namespace}']",
+		NotificationMessage: "test-notification [description: '${description}', overriden-key: '${overriden-key}']",
 		Severity:            "test-severity",
 		ResendWait:          1,
 	}
@@ -133,10 +137,17 @@ func NewTestAlert(resolved, fleet bool) template.Alert {
 			"managed_notification_template": TestNotificationName,
 			"send_managed_notification":     "true",
 			"alertname":                     "TestAlertName",
+			"alertstate":                    "firing",
 			"namespace":                     "openshift-monitoring",
 			"openshift_io_alert_source":     "platform",
 			"prometheus":                    "openshift-monitoring/k8s",
 			"severity":                      "info",
+			"overriden-key":                 "label-value",
+		},
+		Annotations: map[string]string{
+			"description":   "alert-desc",
+			"overriden-key": "annotation-value",
+			"recursive-key": "_${recursive-key}_",
 		},
 		StartsAt: time.Now(),
 		EndsAt:   time.Time{},

--- a/pkg/handlers/helper.go
+++ b/pkg/handlers/helper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/prometheus/alertmanager/template"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,8 +30,6 @@ const (
 	LogFieldManagedNotification        = "managed_notification_cr"
 	LogFieldPostServiceLogOpId         = "post_servicelog_operation_id"
 	LogFieldPostServiceLogFailedReason = "post_servicelog_failed_reason"
-	ServiceLogActivePrefix             = "Issue Notification"
-	ServiceLogResolvePrefix            = "Issue Resolution"
 
 	// Header returned in OCM responses
 	HeaderOperationId = "X-Operation-Id"
@@ -50,11 +47,6 @@ type AMReceiverData template.Data
 
 type AMReceiverAlert template.Alert
 
-// OCMClient enables implementation of OCM Client
-type ocmsdkclient struct {
-	ocm *sdk.Connection
-}
-
 type WebhookReceiverHandler struct {
 	c   client.Client
 	ocm OCMClient
@@ -62,12 +54,6 @@ type WebhookReceiverHandler struct {
 
 type OCMResponseBody struct {
 	Reason string `json:"reason"`
-}
-
-func NewOcmClient(ocm *sdk.Connection) OCMClient {
-	return &ocmsdkclient{
-		ocm: ocm,
-	}
 }
 
 // isValidAlert indicates whether the supplied alert is one that warrants being processed for a notification.

--- a/pkg/handlers/mocks/service_logs.go
+++ b/pkg/handlers/mocks/service_logs.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
+	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 )
 
 // MockOCMClient is a mock of OCMClient interface.
@@ -35,15 +35,15 @@ func (m *MockOCMClient) EXPECT() *MockOCMClientMockRecorder {
 }
 
 // SendServiceLog mocks base method.
-func (m *MockOCMClient) SendServiceLog(arg0, arg1, arg2, arg3 string, arg4 v1alpha1.NotificationSeverity, arg5 string, arg6 []v1alpha1.NotificationReferenceType, arg7 bool) error {
+func (m *MockOCMClient) SendServiceLog(arg0 *v1.LogEntry) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendServiceLog", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "SendServiceLog", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendServiceLog indicates an expected call of SendServiceLog.
-func (mr *MockOCMClientMockRecorder) SendServiceLog(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockOCMClientMockRecorder) SendServiceLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendServiceLog", reflect.TypeOf((*MockOCMClient)(nil).SendServiceLog), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendServiceLog", reflect.TypeOf((*MockOCMClient)(nil).SendServiceLog), arg0)
 }

--- a/pkg/handlers/webhookrhobsreceiver.go
+++ b/pkg/handlers/webhookrhobsreceiver.go
@@ -181,10 +181,13 @@ func (h *WebhookRHOBSReceiverHandler) processAlert(alert template.Alert, mfn oav
 
 	// Send the servicelog for the alert
 	log.WithFields(log.Fields{LogFieldNotificationName: fn.Name}).Info("will send servicelog for notification")
-	err = h.ocm.SendServiceLog(fn.Summary, fn.NotificationMessage, "", hcID, fn.Severity, fn.LogType, fn.References, true)
+	err = BuildAndSendServiceLog(
+		NewServiceLogBuilder(fn.Summary, fn.NotificationMessage, "", hcID, fn.Severity, fn.LogType, fn.References),
+		true, &alert, h.ocm)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{LogFieldNotificationName: fn.Name, LogFieldIsFiring: true}).Error("unable to send a notification")
 		metrics.SetResponseMetricFailure("service_logs")
+		metrics.CountFailedServiceLogs(fn.Name)
 		return err
 	}
 

--- a/pkg/handlers/webhookrhobsreceiver_test.go
+++ b/pkg/handlers/webhookrhobsreceiver_test.go
@@ -32,10 +32,10 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 		testHandler      *WebhookRHOBSReceiverHandler
 		server           *ghttp.Server
 		testAlert        template.Alert
-		testFN           oav1alpha1.FleetNotification
 		testMFN          oav1alpha1.ManagedFleetNotification
 		testMFNR         oav1alpha1.ManagedFleetNotificationRecord
 		mockStatusWriter *clientmocks.MockStatusWriter
+		serviceLog       *ServiceLog
 	)
 
 	BeforeEach(func() {
@@ -49,9 +49,14 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 			ocm: mockOCMClient,
 		}
 		testAlert = testconst.NewTestAlert(false, true)
-		testFN = testconst.NewFleetNotification()
 		testMFN = testconst.NewManagedFleetNotification()
 		testMFNR = testconst.NewManagedFleetNotificationRecord()
+		serviceLog = NewTestServiceLog(
+			ServiceLogActivePrefix+": "+testconst.ServiceLogSummary,
+			testconst.ServiceLogFleetDesc,
+			testconst.TestHostedClusterID,
+			testconst.TestNotification.Severity,
+			"")
 	})
 	AfterEach(func() {
 		server.Close()
@@ -72,7 +77,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 							return nil
 						}),
 					// Send the SL
-					mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+					mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 					mockClient.EXPECT().Status().Return(mockStatusWriter),
 					mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 				)
@@ -96,7 +101,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 						// Send the SL
-						mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 					)
@@ -110,7 +115,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 					// Fetch the MFNR
 					mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
 					// Send the SL
-					mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+					mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 					mockClient.EXPECT().Status().Return(mockStatusWriter),
 					mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 				)
@@ -133,7 +138,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
 						// Send the SL
-						mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 							func(ctx context.Context, mfnr *oav1alpha1.ManagedFleetNotificationRecord, co ...client.UpdateOptions) error {
@@ -167,7 +172,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
 						// Send the SL
-						mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 							func(ctx context.Context, mfnr *oav1alpha1.ManagedFleetNotificationRecord, co ...client.UpdateOptions) error {
@@ -194,7 +199,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
 						// Send the SL
-						mockOCMClient.EXPECT().SendServiceLog(testFN.Summary, testFN.NotificationMessage, "", testconst.TestHostedClusterID, gomock.Any(), gomock.Any(), gomock.Any(), true),
+						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 							func(ctx context.Context, mfnr *oav1alpha1.ManagedFleetNotificationRecord, co ...client.UpdateOptions) error {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,6 +45,12 @@ var (
 			Help: "A count of service log sent based on managedNotification template for the current session",
 		}, []string{"ocm_service", "template", "state"})
 
+	metricFailedServiceLogsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ocm_agent_failed_service_logs_total",
+			Help: "A count of service logs which failed to be sent. This includes service logs which failed to be formatted.",
+		}, []string{"ocm_service", "template"})
+
 	metricServiceLogSentTotal = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ocm_agent_service_log_sent_total",
@@ -58,6 +64,7 @@ var (
 		MetricRequestFailure,
 		MetricResponseFailure,
 		metricServiceLogSent,
+		metricFailedServiceLogsTotal,
 		metricServiceLogSentTotal,
 	}
 )
@@ -135,6 +142,14 @@ func CountServiceLogSent(template, state string) {
 		"ocm_service": "service_logs",
 		"template":    template,
 		"state":       state,
+	}).Inc()
+}
+
+// CountFailedServiceLogs counts the total number of failed service logs (by notification template)
+func CountFailedServiceLogs(template string) {
+	metricFailedServiceLogsTotal.With(prometheus.Labels{
+		"ocm_service": "service_logs",
+		"template":    template,
 	}).Inc()
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Webhook Handlers", func() {
 
 func resetMetrics() {
 	metricServiceLogSent.Reset()
+	metricFailedServiceLogsTotal.Reset()
 	MetricRequestFailure.Reset()
 	MetricResponseFailure.Reset()
 	metricRequestsTotal.Reset()


### PR DESCRIPTION
Place holders are replaced with the alert labels & annotations in the service log to generate

### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR allows to use alert labels & annotations in the service logs sent by `ocm-agent`

### Which Jira/Github issue(s) this PR fixes?

_Implements_ [OSD-19689](https://issues.redhat.com//browse/OSD-19689)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [X] Included documentation changes with PR

