### PR TITLE
OSD-19232 add cluster handler to get cluster object

### DIFF
--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -291,6 +291,9 @@ func (o *serveOptions) Run() error {
 			r.HandleFunc("/upgrade_policies", upgradePolicyHandler.ServeUpgradePolicyList)
 			r.HandleFunc("/upgrade_policies/{upgrade_policy_id}", upgradePolicyHandler.ServeUpgradePolicyGet)
 			r.HandleFunc("/upgrade_policies/{upgrade_policy_id}/state", upgradePolicyHandler.ServeUpgradePolicyState)
+			o.logger.Info("Initialising Cluster handlers")
+			clusterHandler := handlers.NewClusterHandler(sdkclient, internalID)
+			r.HandleFunc("/my_cluster", clusterHandler.ServeClusterGet)
 		}
 	}
 

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -293,7 +293,7 @@ func (o *serveOptions) Run() error {
 			r.HandleFunc("/upgrade_policies/{upgrade_policy_id}/state", upgradePolicyHandler.ServeUpgradePolicyState)
 			o.logger.Info("Initialising Cluster handlers")
 			clusterHandler := handlers.NewClusterHandler(sdkclient, internalID)
-			r.HandleFunc("/my_cluster", clusterHandler.ServeClusterGet)
+			r.HandleFunc("/", clusterHandler.ServeClusterGet)
 		}
 	}
 

--- a/pkg/handlers/cluster.go
+++ b/pkg/handlers/cluster.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	log "github.com/sirupsen/logrus"
+)
+
+type ClusterHandler struct {
+	ocm       *sdk.Connection
+	clusterId string
+}
+
+// For /api/clusters_mgmt/v1/clusters/{cluster_id}
+// https://api.openshift.com/#/default/get_api_clusters_mgmt_v1_clusters__cluster_id_
+func NewClusterHandler(o *sdk.Connection, clusterId string) *ClusterHandler {
+	log.Debug("Creating new cluster object Handler")
+	return &ClusterHandler{
+		ocm:       o,
+		clusterId: clusterId,
+	}
+}
+
+// https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.382/clustersmgmt/v1#Cluster
+func (g *ClusterHandler) GetCluster(clusterID string) (*cmv1.Cluster, error) {
+	log.Debugf("Sending get cluster object request to OCM API: %s", clusterID)
+	request := g.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID)
+	resp, err := request.Get().Send()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body(), nil
+}
+
+// Proxies to
+// https://api.openshift.com/#/default/get_api_clusters_mgmt_v1_clusters__cluster_id_
+func (g *ClusterHandler) ServeClusterGet(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		cluster, err := g.GetCluster(g.clusterId)
+		if err != nil {
+			errorMessageResponse(err, w)
+			return
+		}
+
+		err = cmv1.MarshalCluster(cluster, w)
+		if err != nil {
+			errorMessageResponse(err, w)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+	default:
+		invalidRequestVerbResponse(r.Method, w)
+	}
+}

--- a/pkg/handlers/cluster.go
+++ b/pkg/handlers/cluster.go
@@ -24,9 +24,9 @@ func NewClusterHandler(o *sdk.Connection, clusterId string) *ClusterHandler {
 }
 
 // https://pkg.go.dev/github.com/openshift-online/ocm-sdk-go@v0.1.382/clustersmgmt/v1#Cluster
-func (g *ClusterHandler) GetCluster(clusterID string) (*cmv1.Cluster, error) {
-	log.Debugf("Sending get cluster object request to OCM API: %s", clusterID)
-	request := g.ocm.ClustersMgmt().V1().Clusters().Cluster(clusterID)
+func (g *ClusterHandler) GetCluster() (*cmv1.Cluster, error) {
+	log.Debugf("Sending get cluster object request to OCM API: %s", g.clusterId)
+	request := g.ocm.ClustersMgmt().V1().Clusters().Cluster(g.clusterId)
 	resp, err := request.Get().Send()
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (g *ClusterHandler) GetCluster(clusterID string) (*cmv1.Cluster, error) {
 func (g *ClusterHandler) ServeClusterGet(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
-		cluster, err := g.GetCluster(g.clusterId)
+		cluster, err := g.GetCluster()
 		if err != nil {
 			errorMessageResponse(err, w)
 			return

--- a/pkg/handlers/cluster.go
+++ b/pkg/handlers/cluster.go
@@ -45,12 +45,12 @@ func (g *ClusterHandler) ServeClusterGet(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		err = cmv1.MarshalCluster(cluster, w)
 		if err != nil {
 			errorMessageResponse(err, w)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
 	default:
 		invalidRequestVerbResponse(r.Method, w)
 	}

--- a/pkg/handlers/cluster_test.go
+++ b/pkg/handlers/cluster_test.go
@@ -1,0 +1,268 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"time"
+
+	"github.com/gorilla/mux"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/ocm-agent/pkg/handlers"
+)
+
+var getCluster = `{
+	"kind": "Cluster",
+	"id": "string",
+	"href": "string",
+	"name": "string",
+	"external_id": "string",
+	"infra_id": "string",
+	"display_name": "",
+	"creation_timestamp": "2023-11-19T07:52:20.413713Z",
+	"activity_timestamp": "2023-11-20T10:17:18Z",
+	"expiration_timestamp": "2023-11-20T19:52:18.077225Z",
+	"cloud_provider": {
+	  "kind": "CloudProviderLink",
+	  "id": "aws",
+	  "href": "/api/clusters_mgmt/v1/cloud_providers/aws"
+	},
+	"openshift_version": "4.14.1",
+	"subscription": {
+	  "kind": "SubscriptionLink",
+	  "id": "subid",
+	  "href": "/api/accounts_mgmt/v1/subscriptions/subid"
+	},
+	"region": {
+	  "kind": "CloudRegionLink",
+	  "id": "us-west-2",
+	  "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/us-west-2"
+	},
+	"console": {
+	  "url": "string"
+	},
+	"api": {
+	  "url": "string",
+	  "listening": "external"
+	},
+	"nodes": {
+	  "master": 3,
+	  "infra": 2,
+	  "compute": 2,
+	  "availability_zones": [
+		 "us-west-2a"
+	  ],
+	  "compute_machine_type": {
+		"kind": "MachineTypeLink",
+		"id": "m5.xlarge",
+		"href": "/api/clusters_mgmt/v1/machine_types/m5.xlarge"
+	  },
+	  "infra_machine_type": {
+		"kind": "MachineTypeLink",
+		"id": "r5.xlarge",
+		"href": "/api/clusters_mgmt/v1/machine_types/r5.xlarge"
+	  }
+	},
+	"state": "ready",
+	"flavour": {
+	  "kind": "FlavourLink",
+	  "id": "osd-4",
+	  "href": "/api/clusters_mgmt/v1/flavours/osd-4"
+	},
+	"groups": {
+	  "kind": "GroupListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/groups"
+	},
+	"aws": {
+	  "private_link": false,
+	  "private_link_configuration": {
+		"kind": "PrivateLinkConfigurationLink",
+		"href": "/api/clusters_mgmt/v1/clusters/clusterid/aws/private_link_configuration"
+	  },
+	  "tags": {
+		"red-hat-clustertype": "osd",
+		"red-hat-managed": "true"
+	  },
+	  "audit_log": {
+		"role_arn": ""
+	  },
+	  "ec2_metadata_http_tokens": "optional"
+	},
+	"dns": {
+	  "base_domain": "string"
+	},
+	"network": {
+	  "type": "OVNKubernetes",
+	  "machine_cidr": "10.0.0.0/16",
+	  "service_cidr": "172.30.0.0/16",
+	  "pod_cidr": "10.128.0.0/16",
+	  "host_prefix": 23
+	},
+	"external_configuration": {
+	  "kind": "ExternalConfiguration",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/external_configuration",
+	  "syncsets": {
+		"kind": "SyncsetListLink",
+		"href": "/api/clusters_mgmt/v1/clusters/clusterid/external_configuration/syncsets"
+	  },
+	  "labels": {
+		"kind": "LabelListLink",
+		"href": "/api/clusters_mgmt/v1/clusters/clusterid/external_configuration/labels"
+	  },
+	  "manifests": {
+		"kind": "ManifestListLink",
+		"href": "/api/clusters_mgmt/v1/clusters/clusterid/external_configuration/manifests"
+	  }
+	},
+	"multi_az": false,
+	"managed": true,
+	"ccs": {
+	  "enabled": true,
+	  "disable_scp_checks": false
+	},
+	"version": {
+	  "kind": "Version",
+	  "id": "openshift-v4.14.1",
+	  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.14.1",
+	  "raw_id": "4.14.1",
+	  "channel_group": "stable",
+	  "end_of_life_timestamp": "2025-02-28T00:00:00Z"
+	},
+	"identity_providers": {
+	  "kind": "IdentityProviderListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/identity_providers"
+	},
+	"aws_infrastructure_access_role_grants": {
+	  "kind": "AWSInfrastructureAccessRoleGrantLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/aws_infrastructure_access_role_grants"
+	},
+	"addons": {
+	  "kind": "AddOnInstallationListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/addons"
+	},
+	"ingresses": {
+	  "kind": "IngressListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/ingresses"
+	},
+	"machine_pools": {
+	  "kind": "MachinePoolListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/machine_pools"
+	},
+	"inflight_checks": {
+	  "kind": "InflightCheckListLink",
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/inflight_checks"
+	},
+	"product": {
+	  "kind": "ProductLink",
+	  "id": "osd",
+	  "href": "/api/clusters_mgmt/v1/products/osd"
+	},
+	"status": {
+	  "state": "ready",
+	  "dns_ready": true,
+	  "oidc_ready": false,
+	  "provision_error_message": "",
+	  "provision_error_code": "",
+	  "configuration_mode": "full",
+	  "limited_support_reason_count": 0
+	},
+	"node_drain_grace_period": {
+	  "value": 60,
+	  "unit": "minutes"
+	},
+	"etcd_encryption": false,
+	"billing_model": "standard",
+	"disable_user_workload_monitoring": true,
+	"managed_service": {
+	  "enabled": false,
+	  "managed": false
+	},
+	"hypershift": {
+	  "enabled": false
+	},
+	"byo_oidc": {
+	  "enabled": false
+	},
+	"delete_protection": {
+	  "href": "/api/clusters_mgmt/v1/clusters/clusterid/delete_protection",
+	  "enabled": false
+	}
+  }`
+
+var clusterHandler *handlers.ClusterHandler
+
+var _ = Describe("ClusterHandler", func() {
+	BeforeEach(func() {
+		// Inspired by https://github.com/gdbranco/rosa/blob/67f55df2992b596e810942016833893236ef47f1/cmd/upgrade/cluster/cmd_test.go#L23
+		apiServer = MakeTCPServer()
+
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+		sdkclient, _ := sdk.NewConnectionBuilder().
+			Logger(nil).
+			Tokens(accessToken).
+			URL(apiServer.URL()).
+			Build()
+
+		clusterHandler = handlers.NewClusterHandler(sdkclient, internalId)
+		responseRecorder = httptest.NewRecorder()
+
+	})
+
+	AfterEach(func() {
+		// Close the servers:
+		apiServer.Close()
+	})
+
+	It("should get a cluster object", func() {
+		makeOCMRequest(
+			"GET",
+			http.StatusOK,
+			fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s", internalId),
+			getCluster,
+		)
+		req := httptest.NewRequest("GET", "/cluster", nil)
+
+		req = mux.SetURLVars(
+			req,
+			map[string]string{},
+		)
+
+		clusterHandler.ServeClusterGet(responseRecorder, req)
+
+		var cluster cmv1.Cluster
+
+		// nolint
+		_ = json.NewDecoder(responseRecorder.Result().Body).Decode(&cluster)
+
+		var ocmResp cmv1.Cluster
+
+		// nolint
+		_ = json.Unmarshal([]byte(getCluster), &ocmResp)
+
+		Expect(reflect.DeepEqual(cluster, ocmResp)).To(BeTrue())
+	})
+
+	It("should return an error if ocm returns an error", func() {
+		errorMessage := `{"message": "Cannot connect to ocm api"}`
+		makeOCMRequest(
+			"GET",
+			http.StatusBadRequest,
+			fmt.Sprintf("/api/clusters_mgmt/v1/clusters/%s", internalId),
+			errorMessage,
+		)
+
+		req := httptest.NewRequest("GET", "/cluster", nil)
+
+		clusterHandler.ServeClusterGet(responseRecorder, req)
+
+		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
+	})
+
+})

--- a/pkg/handlers/handlers_common.go
+++ b/pkg/handlers/handlers_common.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func errorMessageResponse(err error, w http.ResponseWriter) {
+	log.Error(err)
+	http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+}
+
+func invalidRequestVerbResponse(method string, w http.ResponseWriter) {
+	log.Errorf("Invalid request verb: %s", method)
+	http.Error(w, "Bad request body", http.StatusBadRequest)
+}

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -1,0 +1,30 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/onsi/gomega/ghttp"
+	. "github.com/openshift-online/ocm-sdk-go/testing"
+)
+
+// shared variables for handler testing
+var apiServer *ghttp.Server
+var responseRecorder *httptest.ResponseRecorder
+var internalId = "internal-id"
+
+func makeOCMRequest(method string, status int, route string, ocmResponse string) {
+	handler := RespondWithJSON(status, ocmResponse)
+	if status == http.StatusNoContent {
+		handler = ghttp.RespondWith(
+			status,
+			nil,
+			http.Header{
+				"Content-Type": []string{
+					"application/json",
+				},
+			},
+		)
+	}
+	apiServer.RouteToHandler(method, route, handler)
+}

--- a/pkg/handlers/upgrade_policies.go
+++ b/pkg/handlers/upgrade_policies.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -177,14 +176,4 @@ func (g *UpgradePoliciesHandler) ServeUpgradePolicyState(w http.ResponseWriter, 
 	default:
 		invalidRequestVerbResponse(r.Method, w)
 	}
-}
-
-func errorMessageResponse(err error, w http.ResponseWriter) {
-	log.Error(err)
-	http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
-}
-
-func invalidRequestVerbResponse(method string, w http.ResponseWriter) {
-	log.Errorf("Invalid request verb: %s", method)
-	http.Error(w, "Bad request body", http.StatusBadRequest)
 }

--- a/pkg/handlers/upgrade_policies_test.go
+++ b/pkg/handlers/upgrade_policies_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gorilla/mux"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/ghttp"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
@@ -69,9 +68,6 @@ var updateUpgradePolicyState = `{
 }`
 
 var upgradePoliciesHandler *handlers.UpgradePoliciesHandler
-var apiServer *ghttp.Server
-var responseRecorder *httptest.ResponseRecorder
-var internalId = "internal-id"
 var upgradePolicyId = "upgrade-policy-id"
 
 var _ = Describe("UpgradePolicies", func() {
@@ -303,19 +299,3 @@ var _ = Describe("UpgradePolicies", func() {
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })
-
-func makeOCMRequest(method string, status int, route string, ocmResponse string) {
-	handler := RespondWithJSON(status, ocmResponse)
-	if status == http.StatusNoContent {
-		handler = ghttp.RespondWith(
-			status,
-			nil,
-			http.Header{
-				"Content-Type": []string{
-					"application/json",
-				},
-			},
-		)
-	}
-	apiServer.RouteToHandler(method, route, handler)
-}


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
Feature

### What this PR does / why we need it?
This PR implements a cluster handler which can get the `*cmv1.Cluster` object from OCM.
- It adds an endpoint /my_cluster . `GET /my_cluster` will return the `Cluster` object of the current cluster.
- Add tests for the cluster handler.
- Move some existing functions from `upgrade_policies.go` and `upgrade_policies_test.go` to `handlers_common.go` and `handlers_test.go` for reuse.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-19232

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

