### PR TITLE
[OSD-19745] - Increase the replicas of the ocm-agent pod as part of the HA task

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -30,7 +30,7 @@ objects:
           services:
           - service_logs
         ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        replicas: 1
+        replicas: 2
         tokenSecret: ocm-access-token
   status: {}
 parameters:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Increase the replicas of the ocm-agent to make it Highly Available. It interdependent with the [PR-102](https://github.com/openshift/ocm-agent-operator/pull/102)

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-19745

