### PR TITLE
Add clusters_mgmt service on all ocm-agent services

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -29,6 +29,7 @@ objects:
           ocmBaseUrl: ${OCM_BASE_URL}
           services:
           - service_logs
+          - clusters_mgmt
         ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         replicas: 1
         tokenSecret: ocm-access-token


### PR DESCRIPTION
### What type of PR is this?
_(feature)_


### What this PR does / why we need it?
To allow MUO and other OCM agent consumers to use the `clusters_mgmt` endpoint, we need to make sure that its manager, the OCM agent operator, has enabled the new endpoint.
This enables the `/clusters` endpoint for all ROSA/OSD clusters, so that they can begin to use it OCM agent as an endpoint proxy. 
https://github.com/openshift/managed-cluster-config/pull/1948 depends on it. 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-19765
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

