### PR TITLE
Add operation ID header to all outbound requests

### DIFF
--- a/pkg/handlers/cluster_test.go
+++ b/pkg/handlers/cluster_test.go
@@ -246,6 +246,7 @@ var _ = Describe("ClusterHandler", func() {
 		// nolint
 		_ = json.Unmarshal([]byte(getCluster), &ocmResp)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(reflect.DeepEqual(cluster, ocmResp)).To(BeTrue())
 	})
 
@@ -262,7 +263,7 @@ var _ = Describe("ClusterHandler", func() {
 
 		clusterHandler.ServeClusterGet(responseRecorder, req)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 	})
-
 })

--- a/pkg/handlers/handlers_common.go
+++ b/pkg/handlers/handlers_common.go
@@ -7,6 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const OCM_OPERATION_ID_HEADER = "X-Operation-Id"
+
 func errorMessageResponse(err error, w http.ResponseWriter) {
 	log.Error(err)
 	http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -5,16 +5,17 @@ import (
 	"net/http/httptest"
 
 	"github.com/onsi/gomega/ghttp"
-	. "github.com/openshift-online/ocm-sdk-go/testing"
+	"github.com/openshift/ocm-agent/pkg/handlers"
 )
 
 // shared variables for handler testing
 var apiServer *ghttp.Server
 var responseRecorder *httptest.ResponseRecorder
 var internalId = "internal-id"
+var ocmOperationId = "ocm-operation-id"
 
 func makeOCMRequest(method string, status int, route string, ocmResponse string) {
-	handler := RespondWithJSON(status, ocmResponse)
+	var handler http.HandlerFunc
 	if status == http.StatusNoContent {
 		handler = ghttp.RespondWith(
 			status,
@@ -23,8 +24,25 @@ func makeOCMRequest(method string, status int, route string, ocmResponse string)
 				"Content-Type": []string{
 					"application/json",
 				},
+				handlers.OCM_OPERATION_ID_HEADER: []string{
+					ocmOperationId,
+				},
 			},
 		)
+	} else {
+		handler = ghttp.RespondWith(
+			status,
+			ocmResponse,
+			http.Header{
+				"Content-Type": []string{
+					"application/json",
+				},
+				handlers.OCM_OPERATION_ID_HEADER: []string{
+					ocmOperationId,
+				},
+			},
+		)
+
 	}
 	apiServer.RouteToHandler(method, route, handler)
 }

--- a/pkg/handlers/upgrade_policies_test.go
+++ b/pkg/handlers/upgrade_policies_test.go
@@ -111,6 +111,7 @@ var _ = Describe("UpgradePolicies", func() {
 		_ = json.Unmarshal([]byte(getUpgradePolicies), &ocmResp)
 		items := ocmResp["items"]
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(reflect.DeepEqual(policies, items)).To(BeTrue())
 	})
 	It("should get an upgrade policy", func() {
@@ -141,6 +142,7 @@ var _ = Describe("UpgradePolicies", func() {
 		// nolint
 		_ = json.Unmarshal([]byte(getUpgradePolicies), &ocmResp)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(reflect.DeepEqual(policy, ocmResp)).To(BeTrue())
 	})
 	It("should get an upgrade policy state", func() {
@@ -169,8 +171,10 @@ var _ = Describe("UpgradePolicies", func() {
 		// nolint
 		_ = json.Unmarshal([]byte(getUpgradePolicies), &ocmResp)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(reflect.DeepEqual(policyState, ocmResp)).To(BeTrue())
 	})
+
 	It("should update an upgrade policy state", func() {
 		makeOCMRequest(
 			"PATCH",
@@ -205,6 +209,7 @@ var _ = Describe("UpgradePolicies", func() {
 		// nolint
 		_ = json.Unmarshal([]byte(getUpgradePolicies), &ocmResp)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(reflect.DeepEqual(policyState, ocmResp)).To(BeTrue())
 	})
 
@@ -239,6 +244,7 @@ var _ = Describe("UpgradePolicies", func() {
 
 		upgradePoliciesHandler.ServeUpgradePolicyList(responseRecorder, req)
 
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 
 		req = httptest.NewRequest("GET", fmt.Sprintf("/upgrade_policies/%s", upgradePolicyId), nil)
@@ -250,6 +256,7 @@ var _ = Describe("UpgradePolicies", func() {
 		)
 
 		upgradePoliciesHandler.ServeUpgradePolicyGet(responseRecorder, req)
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 
 		req = httptest.NewRequest("PATCH", fmt.Sprintf("/upgrade_policies/%s", upgradePolicyId), nil)
@@ -261,6 +268,7 @@ var _ = Describe("UpgradePolicies", func() {
 		)
 
 		upgradePoliciesHandler.ServeUpgradePolicyGet(responseRecorder, req)
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 
 		req = httptest.NewRequest("DELETE", fmt.Sprintf("/upgrade_policies/%s", upgradePolicyId), nil)
@@ -273,6 +281,7 @@ var _ = Describe("UpgradePolicies", func() {
 		)
 
 		upgradePoliciesHandler.ServeUpgradePolicyGet(responseRecorder, req)
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 
 		req = httptest.NewRequest("GET", fmt.Sprintf("/upgrade_policies/%s/state", upgradePolicyId), nil)
@@ -285,6 +294,7 @@ var _ = Describe("UpgradePolicies", func() {
 		)
 
 		upgradePoliciesHandler.ServeUpgradePolicyState(responseRecorder, req)
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 
 		req = httptest.NewRequest("PATCH", fmt.Sprintf("/upgrade_policies/%s/state", upgradePolicyId), nil)
@@ -296,6 +306,7 @@ var _ = Describe("UpgradePolicies", func() {
 		)
 
 		upgradePoliciesHandler.ServeUpgradePolicyState(responseRecorder, req)
+		Expect(reflect.DeepEqual(ocmOperationId, responseRecorder.Header().Get(handlers.OCM_OPERATION_ID_HEADER))).To(BeTrue())
 		Expect(responseRecorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

When testing, we discovered that we are missing the "X-Operation-Id" header from all responses to the new '/clusters' and '/upgrade_policies' endpoints. This means that any non 200 request to consumers of the new OCM Agent API will not be able to track down the source of their bug in the OCM audit logs.

### What this PR does / why we need it?

This PR includes "X-Operation-ID" header on all responses from new 'endpoint proxy' routes.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-20054
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

