### PR TITLE
add pull secret invalid metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,6 +24,7 @@ OCM Agent are managed by [OCM Agent operator](https://github.com/openshift/ocm-a
 |ocm_agent_service_log_sent|Counter|A count of service log sent based on managedNotification template for the current session|
 |ocm_agent_failed_service_logs_total|Counter|A count of service logs which failed to be sent. This includes service logs which failed to be formatted.|
 |ocm_agent_service_log_sent_total|Gauge|A total number of service log being sent based on managedNotification template|
+|ocm_agent_pull_secret_invalid|Gauge|Pull Secret auth token is not valid|
 
 ## Metrics reset
 

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -218,13 +218,17 @@ func (o *serveOptions) Run() error {
 		// Continuously check OCM connection
 		go func() {
 			for {
+				o.logger.Info("OCM connection check starting")
 				response, _ := sdkclient.AccountsMgmt().V1().CurrentAccount().Get().Send()
 				if response.Status() == http.StatusUnauthorized {
+					o.logger.Info("OCM connection check failure")
 					metrics.SetPullSecretInvalidMetricFailure()
+					time.Sleep(1 * time.Minute)
 				} else {
+					o.logger.Info("OCM connection check success")
 					metrics.ResetMetric(metrics.MetricPullSecretInvalid)
+					time.Sleep(5 * time.Minute)
 				}
-				time.Sleep(5 * time.Minute)
 			}
 		}()
 	} else {

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -212,9 +212,11 @@ func (o *serveOptions) Run() error {
 			viper.GetString(config.AccessToken))
 		if err != nil {
 			o.logger.WithError(err).Fatal("Can't initialise OCM sdk.Connection client in non-fleet mode")
+			metrics.SetPullSecretInvalidMetricFailure()
 			return err
 		}
 		o.logger.Info("Connection with OCM initialised successfully in non-fleet mode")
+		metrics.ResetMetric(metrics.MetricPullSecretInvalid)
 	} else {
 		// If fleet mode is enabled, the connection to OCM needs to initiate using client ID and client secret
 		// On the managed cluster, the client ID and secret will be fetched from the secret volume however for

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -226,7 +226,7 @@ func (o *serveOptions) Run() error {
 					time.Sleep(1 * time.Minute)
 				} else {
 					o.logger.Info("OCM connection check success")
-					metrics.ResetMetric(metrics.MetricPullSecretInvalid)
+					metrics.SetPullSecretInvalidMetricSuccess()
 					time.Sleep(5 * time.Minute)
 				}
 			}

--- a/pkg/cli/serve/serve.go
+++ b/pkg/cli/serve/serve.go
@@ -224,6 +224,7 @@ func (o *serveOptions) Run() error {
 				} else {
 					metrics.ResetMetric(metrics.MetricPullSecretInvalid)
 				}
+				time.Sleep(5 * time.Minute)
 			}
 		}()
 	} else {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -57,6 +57,12 @@ var (
 			Help: "A total number of service log being sent based on managedNotification template",
 		}, []string{"ocm_service", "template"})
 
+	MetricPullSecretInvalid = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ocm_agent_pull_secret_invalid",
+			Help: "Pull Secret auth token is not valid",
+		}, []string{})
+
 	metricsList = []prometheus.Collector{
 		metricRequestsTotal,
 		metricFailedRequestsTotal,
@@ -66,6 +72,7 @@ var (
 		metricServiceLogSent,
 		metricFailedServiceLogsTotal,
 		metricServiceLogSentTotal,
+		MetricPullSecretInvalid,
 	}
 )
 
@@ -159,6 +166,11 @@ func SetTotalServiceLogCount(template string, count int32) {
 		"ocm_service": "service_logs",
 		"template":    template,
 	}).Set(float64(count))
+}
+
+// SetPullSecretInvalidMetricFailure sets the metric when ocm connection can not be initiated
+func SetPullSecretInvalidMetricFailure() {
+	MetricPullSecretInvalid.WithLabelValues().Set(float64(1))
 }
 
 // ResetMetric reset the metric with Gauge values

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 			Help: "A total number of service log being sent based on managedNotification template",
 		}, []string{"ocm_service", "template"})
 
-	MetricPullSecretInvalid = prometheus.NewGaugeVec(
+	metricPullSecretInvalid = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ocm_agent_pull_secret_invalid",
 			Help: "Pull Secret auth token is not valid",
@@ -72,7 +72,7 @@ var (
 		metricServiceLogSent,
 		metricFailedServiceLogsTotal,
 		metricServiceLogSentTotal,
-		MetricPullSecretInvalid,
+		metricPullSecretInvalid,
 	}
 )
 
@@ -168,9 +168,14 @@ func SetTotalServiceLogCount(template string, count int32) {
 	}).Set(float64(count))
 }
 
+// SetPullSecretInvalidMetricSuccess sets the metric when ocm connection is successful
+func SetPullSecretInvalidMetricSuccess() {
+	metricPullSecretInvalid.WithLabelValues().Set(float64(0))
+}
+
 // SetPullSecretInvalidMetricFailure sets the metric when ocm connection can not be initiated
 func SetPullSecretInvalidMetricFailure() {
-	MetricPullSecretInvalid.WithLabelValues().Set(float64(1))
+	metricPullSecretInvalid.WithLabelValues().Set(float64(1))
 }
 
 // ResetMetric reset the metric with Gauge values

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Webhook Handlers", func() {
 			It("does so correctly", func() {
 				SetPullSecretInvalidMetricFailure()
 				expectedMetric := fmt.Sprintf("%s%s%d\n", metricHelpHeader, metricValueHeader, 1)
-				err := testutil.CollectAndCompare(MetricPullSecretInvalid, strings.NewReader(expectedMetric))
+				err := testutil.CollectAndCompare(metricPullSecretInvalid, strings.NewReader(expectedMetric))
 				Expect(err).To(BeNil())
 			})
 		})
@@ -187,5 +187,5 @@ func resetMetrics() {
 	metricRequestsTotal.Reset()
 	metricFailedRequestsTotal.Reset()
 	metricRequestsByService.Reset()
-	MetricPullSecretInvalid.Reset()
+	metricPullSecretInvalid.Reset()
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -159,6 +159,24 @@ var _ = Describe("Webhook Handlers", func() {
 		})
 
 	})
+
+	Context("Pull Secret Invalid metric", func() {
+		var (
+			metricHelpHeader = `
+# HELP ocm_agent_pull_secret_invalid Pull Secret auth token is not valid
+# TYPE ocm_agent_pull_secret_invalid gauge
+`
+			metricValueHeader = "ocm_agent_pull_secret_invalid{} "
+		)
+		When("the metric is set", func() {
+			It("does so correctly", func() {
+				SetPullSecretInvalidMetricFailure()
+				expectedMetric := fmt.Sprintf("%s%s%d\n", metricHelpHeader, metricValueHeader, 1)
+				err := testutil.CollectAndCompare(MetricPullSecretInvalid, strings.NewReader(expectedMetric))
+				Expect(err).To(BeNil())
+			})
+		})
+	})
 })
 
 func resetMetrics() {
@@ -169,4 +187,5 @@ func resetMetrics() {
 	metricRequestsTotal.Reset()
 	metricFailedRequestsTotal.Reset()
 	metricRequestsByService.Reset()
+	MetricPullSecretInvalid.Reset()
 }


### PR DESCRIPTION
### What type of PR is this?
this PR is a proposal to add a new metric: `ocm_agent_pull_secret_invalid`.

### What this PR does / why we need it?
with this PR, we will have a metric on every OSD/ROSA cluster that will allow us to add an alert such as https://github.com/openshift/managed-cluster-config/pull/1847 to be used to prevent other alerts such as in https://github.com/openshift/managed-cluster-config/pull/1848.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18372

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

