### PR TITLE
Osd 20180 adding dependabot to automatically bump the base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/build"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "openshift/release"
+        # don't automatically upgrade golang version here

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -46,7 +46,7 @@ The easiest and the cleanest way to update the go.mod dependencies is to do the 
 
 ### Updating the base image version
 
-In order to align to latest base image, can refer to [ubi8/ubi-micro:latest](https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a?tag=latest) image from the software catalog and update the [Dockerfile](https://github.com/openshift/ocm-agent/blob/master/build/Dockerfile) file in [openshift/ocm-agent](https://github.com/openshift/ocm-agent) repository.
+The base image [ubi8/ubi-micro:latest](https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a?tag=latest) will be automatically checked and maintained by the dependabot.The dependabot configuration file is located in [openshift/ocm-agent/.github](https://github.com/openshift/ocm-agent/tree/master/.github) folder. The dependabot will check the base image version weekly and create the PR to update the [Dockerfile](https://github.com/openshift/ocm-agent/blob/master/build/Dockerfile) file if there is a base image version update.
 
 ### Rebuilding the controller-runtime mocks for tests
 


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_
Repo enhancement: Automatically bump the base image 

### What this PR does / why we need it?

Using Dependabot to automatically bump the base image so we can reduce the manual effort for dependency maintenance.

### Which Jira/Github issue(s) this PR fixes?

[_Fixes OSD-20180](https://issues.redhat.com/browse/OSD-20180)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

