### PR TITLE
remove status field from openshift template

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -33,7 +33,6 @@ objects:
         ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         replicas: 2
         tokenSecret: ocm-access-token
-  status: {}
 parameters:
 - name: IMAGE_TAG
   required: true


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
unused field

the field is not present in the SSS object on the cluster. here is some output from qontract-reconcile when trying to deploy:
```
[DEBUG] [DRY-RUN] [three_way_diff_strategy.py:three_way_diff_using_hash:150] - Desired and Current objects differ -> Apply: [{'op': 'add', 'path': '/status', 'value': {}}]
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

