### PR TITLE
Fix: source label verification for fleet-mode

### DIFF
--- a/pkg/handlers/helper.go
+++ b/pkg/handlers/helper.go
@@ -81,13 +81,8 @@ func isValidAlert(alert template.Alert, fleetMode bool) bool {
 	}
 
 	if fleetMode {
-		// An alert in fleet mode should come from a source of HCP/DP
-		if name, ok := alert.Labels[AMLabelAlertSourceName]; ok {
-			if name != AMLabelAlertSourceHCP && name != AMLabelAlertSourceDP {
-				log.WithField(LogFieldAlertname, alertname).Error("fleet mode alert has no valid source")
-				return false
-			}
-		} else {
+		// An alert in fleet mode must have a source label
+		if _, ok := alert.Labels[AMLabelAlertSourceName]; !ok {
 			log.WithField(LogFieldAlertname, alertname).Error("fleet mode alert has no source")
 			return false
 		}

--- a/test/template-alert-fleet-notification.json
+++ b/test/template-alert-fleet-notification.json
@@ -15,7 +15,7 @@
           "severity": "info",
           "_mc_id": "${MANAGEMENT_CLUSTER_ID}",
           "_id": "${HC_ID}",
-          "source": "HCP"
+          "source": "MC"
         },
         "annotations": {
           "description": ""


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

`source` has been modified for management clusters, it's now `MC` instead of `HCP`. We should just check if a source label is present as part of the fleet-mode precheck instead of checking the value.

Error example:
```
time="2024-01-30T10:42:49Z" level=error msg="fleet mode alert has no valid source" alertname=0xc000711530
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

