### PR TITLE
Fix(OSD-20662): race condition in fleet mode alert handling

### DIFF
--- a/pkg/consts/test/test.go
+++ b/pkg/consts/test/test.go
@@ -114,7 +114,7 @@ func NewFleetNotification() ocmagentv1alpha1.FleetNotification {
 func NewManagedFleetNotification(limited_support bool) ocmagentv1alpha1.ManagedFleetNotification {
 	mfn := ocmagentv1alpha1.ManagedFleetNotification{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-mfn",
+			Name:      TestNotificationName,
 			Namespace: "openshift-ocm-agent-operator",
 		},
 		Spec: ocmagentv1alpha1.ManagedFleetNotificationSpec{
@@ -138,6 +138,27 @@ func NewManagedFleetNotificationRecord() ocmagentv1alpha1.ManagedFleetNotificati
 		Status: ocmagentv1alpha1.ManagedFleetNotificationRecordStatus{
 			ManagementCluster:        TestManagedClusterID,
 			NotificationRecordByName: nil,
+		},
+	}
+}
+
+func NewManagedFleetNotificationRecordWithStatus() ocmagentv1alpha1.ManagedFleetNotificationRecord {
+	return ocmagentv1alpha1.ManagedFleetNotificationRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestManagedClusterID,
+			Namespace: "openshift-ocm-agent-operator",
+		},
+		Status: ocmagentv1alpha1.ManagedFleetNotificationRecordStatus{
+			ManagementCluster: TestManagedClusterID,
+			NotificationRecordByName: []ocmagentv1alpha1.NotificationRecordByName{
+				{
+					NotificationName: TestNotificationName,
+					ResendWait:       0,
+					NotificationRecordItems: []ocmagentv1alpha1.NotificationRecordItem{
+						{HostedClusterID: TestHostedClusterID},
+					},
+				},
+			},
 		},
 	}
 }
@@ -172,7 +193,7 @@ func NewTestAlert(resolved bool, fleet bool) template.Alert {
 	}
 
 	if fleet {
-		alert.Labels["source"] = "HCP"
+		alert.Labels["source"] = "MC"
 		alert.Labels["_mc_id"] = TestManagedClusterID
 		alert.Labels["_id"] = TestHostedClusterID
 	}

--- a/test/test-fleet-mode-alerts.sh
+++ b/test/test-fleet-mode-alerts.sh
@@ -86,6 +86,7 @@ sleep 3
 EXPECTED_COUNT=$((${PRE_LS_COUNT} + 1))
 check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}
 
+
 # Test Limited support for resolved alert using defaults. 
 echo
 echo "### TEST 3 - Remove Limited Support for resolved alert"
@@ -96,4 +97,19 @@ create-alert --hc-id ${EXTERNAL_ID} --mc-id $random_mc_id --template "$TEMPLATE_
 post-alert ${ALERT_FILE}
 sleep 3
 EXPECTED_COUNT=$((${PRE_LS_COUNT} - 1))
+check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}
+
+# Test parallel execution 
+echo
+echo "### TEST 4 - Parallel execution"
+echo
+ALERT_FILE_FIRING=/tmp/firing-alert.json
+create-alert --hc-id ${EXTERNAL_ID} --mc-id $random_mc_id --template "$TEMPLATE_ALERT_JSON_FILE" -t "oidc-deleted-notification" > ${ALERT_FILE_FIRING}
+PRE_LS_COUNT=$(get-limited-support-count ${EXTERNAL_ID})
+
+for ((i=1; i<=10; i++)); do
+  post-alert ${ALERT_FILE_FIRING} &
+done
+sleep 15 # Wait for everything to be handled
+EXPECTED_COUNT=$((${PRE_LS_COUNT} + 10))
 check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}


### PR DESCRIPTION
### What type of PR is this?
bug


### What this PR does / why we need it?

Fixes race condition in fleet mode alert handling. We were not handling conflicts on kube resource updates.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-20662](https://issues.redhat.com//browse/OSD-20662)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

