### PR TITLE
fix(OSD-20857): resend LS only when resolved

### DIFF
--- a/pkg/handlers/webhookrhobsreceiver_test.go
+++ b/pkg/handlers/webhookrhobsreceiver_test.go
@@ -139,6 +139,20 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 				err := testHandler.processFiringAlert(testAlertFiring, &testLimitedSupportMFN)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
+			Context("When the MFN of type limited support for a firing alert and a previous firing notification hasn't resolved yet", func() {
+				It("Doesn't re-send limited support", func() {
+					// Increment firing status (firing = 1 and resolved = 0)
+					_, err := testMFNRWithStatus.UpdateNotificationRecordItem(testconst.TestNotificationName, testconst.TestHostedClusterID, true)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Fetch the MFNR
+					mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNRWithStatus)
+					// Return right after as there was already a LS sent that didn't resolve yet
+
+					err = testHandler.processFiringAlert(testAlertFiring, &testLimitedSupportMFN)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
 		})
 
 		Context("When the MFN of type limited support for a firing alert", func() {

--- a/test/test-fleet-mode-alerts.sh
+++ b/test/test-fleet-mode-alerts.sh
@@ -85,6 +85,10 @@ post-alert ${ALERT_FILE}
 sleep 3
 EXPECTED_COUNT=$((${PRE_LS_COUNT} + 1))
 check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}
+# Resend alert - we should not resend limited support as it never resolved
+post-alert ${ALERT_FILE}
+sleep 3
+check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}
 
 
 # Test Limited support for resolved alert using defaults. 


### PR DESCRIPTION
**Note:** **this is a branch off https://github.com/openshift/ocm-agent/pull/82 - once PR 82 is merged, the diff here will be much smaller.** 

### What type of PR is this?
bug

### What this PR does / why we need it?

When alertmanager restarts, all alerts are resent. This PR adds a check to make sure we don't send limited support if it's already active. No changes to service logs.

I also included an E2E test for this.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-20857](https://issues.redhat.com//browse/OSD-20857)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

