### PR TITLE
Fix: CanBeSent does not rely on existing object

### DIFF
--- a/pkg/handlers/helper.go
+++ b/pkg/handlers/helper.go
@@ -24,6 +24,7 @@ const (
 	AMLabelAlertHCID           = "_id"
 
 	LogFieldNotificationName           = "notification"
+	LogFieldNotificationRecordName     = "notification_record"
 	LogFieldResendInterval             = "resend_interval"
 	LogFieldAlertname                  = "alertname"
 	LogFieldAlert                      = "alert"

--- a/pkg/handlers/webhookrhobsreceiver_test.go
+++ b/pkg/handlers/webhookrhobsreceiver_test.go
@@ -88,10 +88,6 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 							Expect(mfnr.Name).To(Equal(testconst.TestManagedClusterID))
 							return nil
 						}),
-					// Initially add the MC name to the status as it isn't set yet
-					mockClient.EXPECT().Status().Return(mockStatusWriter),
-					mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
-
 					// Update status for the handled alert
 					mockClient.EXPECT().Status().Return(mockStatusWriter),
 					mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
@@ -205,9 +201,6 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 					gomock.InOrder(
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
-						// Update the status
-						mockClient.EXPECT().Status().Return(mockStatusWriter),
-						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 						// Send the SL
 						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 
@@ -237,16 +230,12 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 					gomock.InOrder(
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
-						mockClient.EXPECT().Status().Return(mockStatusWriter),
-						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 
 						// Send the SL
 						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 
 						// Update status (create the record item)
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
-						mockClient.EXPECT().Status().Return(mockStatusWriter),
-						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 
 						mockClient.EXPECT().Status().Return(mockStatusWriter),
 						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -311,9 +300,6 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 					gomock.InOrder(
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),
-						// Update the status
-						mockClient.EXPECT().Status().Return(mockStatusWriter),
-						mockStatusWriter.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil),
 						// Send the SL
 						mockOCMClient.EXPECT().SendServiceLog(serviceLog).Return(nil),
 
@@ -347,6 +333,7 @@ var _ = Describe("RHOBS Webhook Handlers", func() {
 							},
 						},
 					}
+					testMFN.Spec.FleetNotification.ResendWait = 24
 					gomock.InOrder(
 						// Fetch the MFNR
 						mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).SetArg(2, testMFNR),

--- a/test/test-fleet-mode-alerts.sh
+++ b/test/test-fleet-mode-alerts.sh
@@ -103,6 +103,7 @@ sleep 3
 EXPECTED_COUNT=$((${PRE_LS_COUNT} - 1))
 check-limited-support-count ${EXTERNAL_ID} ${EXPECTED_COUNT}
 
+random_mc_id=$(tr -dc 'a-z' < /dev/urandom | head -c 5)
 # Test parallel execution 
 echo
 echo "### TEST 4 - Parallel execution"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

**The bug:** 
- with the [latest fix of a nil ptr deref](https://github.com/openshift/ocm-agent-operator/pull/111) in `ocm-agent-operator`, recorditems with a `nil` `lastUpdatedTimestamp` are automatically garbage collected
- we currently need to pre-create recorditems for the `CanBeSent()` function, but the timestamp isn't set

**Result:** the recorditems we create are instantly garbage collected by ocm-agent-operator

**The fix:**

`FiringCanBeSent()` defined in `ocm-agent-operator` (API) requires a `managedfleetnotificationrecord` to exist: https://github.com/openshift/ocm-agent-operator/blob/e0178327b55ced0475e276c147e7b73b7c4cbfe1/api/v1alpha1/managedfleetnotificationrecord_types.go#L145
Due to this, we needed to create it before the check. 

This PR re-implements `firingCanBeSent()` to not rely on the existing record: if no record exists, the notification can automatically be sent. 
With this change, the creation and update of the `managedfleetnotificationrecord / item` was moved into a single function that is called once OA handles a managed fleet notification. This allows creating the recorditem directly with the timestamp in a single `Update()` call.

Note that we can delete the `FiringCanBeSent` in ocm-agent-operator after this PR.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

