### PR TITLE
OSD-20982: add check for the recorditem states to integration tests

### DIFF
--- a/pkg/handlers/webhookrhobsreceiver.go
+++ b/pkg/handlers/webhookrhobsreceiver.go
@@ -286,7 +286,7 @@ func (h *WebhookRHOBSReceiverHandler) updateManagedFleetNotificationRecord(alert
 		// Fetch the ManagedFleetNotificationRecord, or create it if it does not already exist
 		mfnr, err := h.getOrCreateManagedFleetNotificationRecord(mcID, hcID, mfn)
 		if err != nil {
-			log.WithFields(log.Fields{LogFieldNotificationRecordName: mfnr.Name}).Infof("getOrCreate of managedfleetnotificationrecord failed: %s. Retrying in case of conflict error", err.Error())
+			log.WithFields(log.Fields{LogFieldNotificationRecordName: mcID}).Infof("getOrCreate of managedfleetnotificationrecord failed: %s. Retrying in case of conflict error", err.Error())
 			return err
 		}
 

--- a/test/util/oc.sh
+++ b/test/util/oc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+## oc.sh - Library with different oc helper functions
+
+function get-mfnri-firingcount() {
+    MC_ID=${1}
+    CLUSTER_ID=${2}
+    FIRING_NOTIFICATIONS_SENT_COUNT=$(oc get managedfleetnotificationrecords ${MC_ID} -n openshift-ocm-agent-operator -ojson | jq -r ".status.notificationRecordByName[0].notificationRecordItems[] | select(.hostedClusterID == \"$CLUSTER_ID\") | .firingNotificationSentCount")
+    echo ${FIRING_NOTIFICATIONS_SENT_COUNT}
+}
+
+function get-mfnri-resolvedcount() {
+    MC_ID=${1}
+    CLUSTER_ID=${2}
+    RESOLVED_NOTIFICATIONS_SENT_COUNT=$(oc get managedfleetnotificationrecords ${MC_ID} -n openshift-ocm-agent-operator -ojson | jq -r ".status.notificationRecordByName[0].notificationRecordItems[] | select(.hostedClusterID == \"$CLUSTER_ID\") | .resolvedNotificationSentCount")
+    echo ${RESOLVED_NOTIFICATIONS_SENT_COUNT}
+}
+
+function check-mfnri-count() {
+    MC_ID=${1}
+    CLUSTER_ID=${2}
+	EXPECTED_COUNT_FIRING=${3}
+    EXPECTED_COUNT_RESOLVED=${4}
+
+    ACTUAL_COUNT_FIRING=$(get-mfnri-firingcount ${MC_ID} ${CLUSTER_ID})
+    ACTUAL_COUNT_RESOLVED=$(get-mfnri-resolvedcount ${MC_ID} ${CLUSTER_ID})
+	echo
+    if [[ ${ACTUAL_COUNT_FIRING} = ${EXPECTED_COUNT_FIRING} && ${ACTUAL_COUNT_RESOLVED} = ${EXPECTED_COUNT_RESOLVED} ]]
+    then
+        echo "TEST PASSED = Expected firingNotificationSentCount: ${EXPECTED_COUNT_FIRING}, Got Firing count: ${ACTUAL_COUNT_FIRING}."
+        echo "              Expected resolvedNotificationSentCount: ${EXPECTED_COUNT_RESOLVED}, Got Resolved count: ${ACTUAL_COUNT_RESOLVED}."
+    else
+        echo "TEST FAILED = Expected firingNotificationSentCount: ${EXPECTED_COUNT_FIRING}, Got Firing count: ${ACTUAL_COUNT_FIRING}."
+        echo "              Expected resolvedNotificationSentCount: ${EXPECTED_COUNT_RESOLVED}, Got Resolved count: ${ACTUAL_COUNT_RESOLVED}."
+    fi
+}


### PR DESCRIPTION
### What type of PR is this?
test


### What this PR does / why we need it?

This PR adds more tests for the previous PR https://github.com/openshift/ocm-agent/pull/89. These tests would have caught the unwanted garbage collection of recorditems before it made it to prod.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

