### PR TITLE
Add OcmAgent selectorsyncset for management clusters

### DIFF
--- a/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
+++ b/hack/00-ocm-agent.selectorsyncset.yaml.tmpl
@@ -33,6 +33,36 @@ objects:
         ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         replicas: 2
         tokenSecret: ocm-access-token
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    creationTimestamp: null
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: "true"
+    name: ocm-agent-management-cluster-fleet-resources
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: "true"
+        ext-hypershift.openshift.io/cluster-type: "management-cluster"
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: OcmAgent
+      metadata:
+        name: ocm-agent-fleet
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetMode: true
+        agentConfig:
+          ocmBaseUrl: ${OCM_BASE_URL}
+          services:
+          - service_logs
+        ocmAgentImage: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        replicas: 2
+        tokenSecret: ocm-access-token-fleet
 parameters:
 - name: IMAGE_TAG
   required: true


### PR DESCRIPTION
### What type of PR is this?
_(feature)_


### What this PR does / why we need it?
This pull request demonstrates how to deploy OCM agent in fleet mode on management clusters. 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-20371
### Special notes for your reviewer:
Spike doc explaining how to test this: https://docs.google.com/document/d/1nw4XeEftcq67M9Jg9ljJd5W09y-8mE05KHdXxgk5QOk/edit
### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

