### PR TITLE
remove the validating for source field for fleet mode alerts

### DIFF
--- a/pkg/consts/test/test.go
+++ b/pkg/consts/test/test.go
@@ -6,13 +6,14 @@ import (
 
 	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
-	"github.com/openshift/ocm-agent/pkg/consts"
 	"github.com/prometheus/alertmanager/template"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/ocm-agent/pkg/consts"
 )
 
 const (
@@ -193,7 +194,6 @@ func NewTestAlert(resolved bool, fleet bool) template.Alert {
 	}
 
 	if fleet {
-		alert.Labels["source"] = "MC"
 		alert.Labels["_mc_id"] = TestManagedClusterID
 		alert.Labels["_id"] = TestHostedClusterID
 	}

--- a/pkg/handlers/helper.go
+++ b/pkg/handlers/helper.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/openshift/ocm-agent/pkg/ocm"
 	"github.com/prometheus/alertmanager/template"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/ocm-agent/pkg/ocm"
 
 	_ "github.com/golang/mock/mockgen/model"
 )
@@ -17,9 +18,6 @@ const (
 	AMLabelAlertName           = "alertname"
 	AMLabelTemplateName        = "managed_notification_template"
 	AMLabelManagedNotification = "send_managed_notification"
-	AMLabelAlertSourceName     = "source"
-	AMLabelAlertSourceHCP      = "HCP"
-	AMLabelAlertSourceDP       = "DP"
 	AMLabelAlertMCID           = "_mc_id"
 	AMLabelAlertHCID           = "_id"
 
@@ -82,12 +80,6 @@ func isValidAlert(alert template.Alert, fleetMode bool) bool {
 	}
 
 	if fleetMode {
-		// An alert in fleet mode must have a source label
-		if _, ok := alert.Labels[AMLabelAlertSourceName]; !ok {
-			log.WithField(LogFieldAlertname, alertname).Error("fleet mode alert has no source")
-			return false
-		}
-
 		// An alert in fleet mode must have a management cluster ID label
 		if _, ok := alert.Labels[AMLabelAlertMCID]; !ok {
 			log.WithField(LogFieldAlertname, alertname).Error("fleet mode alert has no management cluster ID")

--- a/pkg/handlers/helper_test.go
+++ b/pkg/handlers/helper_test.go
@@ -47,11 +47,6 @@ var _ = Describe("Webhook Handler Helpers", func() {
 				r := isValidAlert(testFleetAlert, true)
 				Expect(r).To(BeTrue())
 			})
-			It("should invalidate a fleet alert with no source label", func() {
-				delete(testFleetAlert.Labels, AMLabelAlertSourceName)
-				r := isValidAlert(testFleetAlert, true)
-				Expect(r).To(BeFalse())
-			})
 			It("should invalidate a fleet alert with no MC label", func() {
 				delete(testFleetAlert.Labels, AMLabelAlertMCID)
 				r := isValidAlert(testFleetAlert, true)


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
We are validating the alert with label before proceed it with the ocm-agent service log sending.
There was a `source` label when the alerts are handled by the rhobs, but the field is not there when we move the alert handling to the obo stack running on the management cluster.
The existing validator with alert label _id and _mc_id should be able to indicate the alert is valid.

### Which Jira/Github issue(s) this PR fixes?

Fixes #[OSD-25042](https://issues.redhat.com//browse/OSD-25042)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

