### PR TITLE
Updating the go version to 1.22 in the docker file

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.22 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir


### PR DESCRIPTION
### What type of PR is this?
_maintenance_


### What this PR does / why we need it?
Based on the existing supported versions of OCP, https://github.com/openshift/ocm-agent should atleast support Go 1.22 ahead till version 4.17. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-25318_

