### PR TITLE
Updating base image to match boilerplate for Go 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ docs:
 # Installed using instructions from: https://golangci-lint.run/usage/install/#linux-and-windows
 getlint:
 	@mkdir -p $(GOPATH)/bin
-	@ls $(GOPATH)/bin/golangci-lint 1>/dev/null || (echo "Installing golangci-lint..." && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.52.2)
+	@ls $(GOPATH)/bin/golangci-lint 1>/dev/null || (echo "Installing golangci-lint..." && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.61.0)
 
 .PHONY: lint
 lint: getlint

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ getlint:
 
 .PHONY: lint
 lint: getlint
-	$(GOPATH)/bin/golangci-lint run
+	$(GOPATH)/bin/golangci-lint run --timeout=5m
 
 mockgen: ensure-mockgen
 	go generate $(GOBUILDFLAGS) ./...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.22 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -98,7 +98,7 @@ func (b *ServiceLogBuilder) Build(firing bool, alert *template.Alert) (*ServiceL
 	}
 
 	// Handle DocReferences
-	if b.references != nil && len(b.references) > 0 {
+	if len(b.references) > 0 {
 		for _, ref := range b.references {
 			docReferences = append(docReferences, string(ref))
 		}


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?
Raising this PR to fix the base image for ocm-agent to not use Centos base image but aligning it to use boilerplate image. Without this fix, ocm-agent has failure like:
```shell
2024-09-30T04:12:24.317367291+00:00 stderr F ocm-agent: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ocm-agent)
2024-09-30T04:12:24.317367291+00:00 stderr F ocm-agent: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ocm-agent)
```

Thanks @tkong-redhat and @a7vicky to figure out the issue :+1: 
