### PR TITLE
OSD-25814 revert base image because of critical issue in the base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?
Currently there is a critical issue in the base image which leads ocm-agent failed to start.
We need to revert the base image so ocm-agent could start properly and make the cluster back to normal status.
### Which Jira/Github issue(s) this PR fixes?
[OSD-25814](https://issues.redhat.com/browse/OSD-25814)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

