### PR TITLE
Osd 20959 update go and test

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.18 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.10-20
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.10-22
 
 LABEL io.openshift.managed.name="ocm-agent" \
   io.openshift.managed.description="Agent to interact with OCM on managed clusters"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ocm-agent
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/golang/mock v1.6.0
@@ -44,8 +44,8 @@ require (
 	github.com/go-openapi/swag v0.22.9 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
-	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,11 +119,11 @@ github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+C
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
-github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -9,21 +10,26 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/ghttp"
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	. "github.com/openshift-online/ocm-sdk-go/testing"
 	testconst "github.com/openshift/ocm-agent/pkg/consts/test"
 )
 
 func TestOCMClient(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "ocm client Suite")
 }
 
-var _ = Describe("ServiceLogsHandler", func() {
+var _ = Describe("OCM client Handler", func() {
 	var (
-		ocmConnection *sdk.Connection
-		ocmClient     OCMClient
-		serviceLog    *ServiceLog
-		err           error
-		mockServer    *Server
+		ocmConnection          *sdk.Connection
+		ocmClient              OCMClient
+		serviceLog             *ServiceLog
+		err                    error
+		mockServer             *Server
+		clusterUUID            string
+		limitedSupportReason   *cmv1.LimitedSupportReason
+		limitedSupportReasonID string
 	)
 
 	// Setup the testing environment to make mock server, OCM connection and mock token.
@@ -46,6 +52,10 @@ var _ = Describe("ServiceLogsHandler", func() {
 			testconst.TestNotification.LogType,
 			testconst.TestNotification.References,
 		)
+
+		clusterUUID = "BD845DE4-5C16-4067-A868-15B02D55CCEF"
+		limitedSupportReasonID = "D6BB28C8-0EB2-4EB3-B843-91802F1538C4"
+		limitedSupportReason, _ = cmv1.NewLimitedSupportReason().Summary("Test limited support").Details("Limited support due to test").DetectionType(cmv1.DetectionTypeManual).Build()
 
 		mockServer.AppendHandlers(
 			RespondWith(http.StatusCreated, `{}`, http.Header{"Content-Type": []string{"application/json"}}),
@@ -80,5 +90,174 @@ var _ = Describe("ServiceLogsHandler", func() {
 			Expect(err.Error()).To(Equal(expectedErrorMessage))
 		})
 
+	})
+	Context("Limit support", func() {
+		It("should not return an error on successful post", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("POST", "/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons"),
+				RespondWith(
+					http.StatusCreated,
+					`{"kind": "LimitedSupportReason", "details": "Limited support due to test","detection_type": "manual","summary": "Test limited support"}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			err := ocmClient.SendLimitedSupport(clusterUUID, limitedSupportReason)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error when no internal id was found", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":0,"size":0,"total":0,"items": []}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			err := ocmClient.SendLimitedSupport(clusterUUID, limitedSupportReason)
+			Expect(err).To(HaveOccurred())
+
+			expectedErrorMessage := fmt.Sprintf("can't get internal id: cluster with external id %s not found in OCM database", clusterUUID)
+			Expect(err.Error()).To(Equal(expectedErrorMessage))
+		})
+
+		It("should return an error on failed post", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("POST", "/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons"),
+				RespondWith(
+					http.StatusInternalServerError,
+					`{"kind": "Error", "id": "400", "href": "/api/clusters_mgmt/v1/errors/400", "code": "CLUSTERS-MGMT-400", "reason": "An internal server error occurred"}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			err := ocmClient.SendLimitedSupport(clusterUUID, limitedSupportReason)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return an error on successfully delete limited support", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			requestPath := fmt.Sprintf("/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons/%s", limitedSupportReasonID)
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("DELETE", requestPath),
+				RespondWith(
+					http.StatusOK,
+					``,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			err := ocmClient.RemoveLimitedSupport(clusterUUID, limitedSupportReasonID)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error on failed deletion", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			requestPath := fmt.Sprintf("/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons/%s", limitedSupportReasonID)
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("DELETE", requestPath),
+				RespondWith(
+					http.StatusInternalServerError,
+					`{"kind": "Error", "id": "400", "href": "/api/clusters_mgmt/v1/errors/400", "code": "CLUSTERS-MGMT-400", "reason": "An internal server error occurred"}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			err := ocmClient.RemoveLimitedSupport(clusterUUID, limitedSupportReasonID)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return an error on successfully get limited support", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"LimitedSupportReasonList","page":1,"size":1,"total":1,"items": 
+						[
+							{
+								"kind":"LimitedSupportReason",
+      							"id":"bef7fe9e-105d-11f0-ad74-0a580a800465",
+      							"href":"/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons/bef7fe9e-105d-11f0-ad74-0a580a800465",
+      							"summary":"TEST",
+      							"details":"TEST_DETAIL"
+				            }
+						]
+					}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			limitedSupportReasons, err := ocmClient.GetLimitedSupportReasons(clusterUUID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(limitedSupportReasons)).To(Equal(1))
+		})
+
+		It("should return an error on failed to get limited support", func() {
+			mockServer.SetHandler(0, CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters"),
+				RespondWith(
+					http.StatusOK,
+					`{"kind":"ClusterList","page":1,"size":1,"total":1,"items": [{"kind":"Cluster","id":"internal-id"}]}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+
+			mockServer.AppendHandlers(CombineHandlers(
+				VerifyRequest("GET", "/api/clusters_mgmt/v1/clusters/internal-id/limited_support_reasons"),
+				RespondWith(
+					http.StatusNotFound,
+					`{"kind": "Error", "id": "404", "href": "/api/clusters_mgmt/v1/errors/404", "code": "CLUSTERS-MGMT-404", "reason": "The requested resource doesn't exist"}`,
+					http.Header{"Content-Type": []string{"application/json"}},
+				),
+			))
+			limitedSupportReasons, err := ocmClient.GetLimitedSupportReasons(clusterUUID)
+			Expect(err).To(HaveOccurred())
+			expectedErrorMessage := "can't get limited support reasons: status is 404, identifier is '404' and code is 'CLUSTERS-MGMT-404': The requested resource doesn't exist"
+			Expect(err.Error()).To(Equal(expectedErrorMessage))
+
+			Expect(limitedSupportReasons).To(BeNil())
+
+		})
 	})
 })


### PR DESCRIPTION
### What type of PR is this
Bump go version to 1.22 which compatible with openshift 4.18.
Patch dependencies for security
Add more test cases for limited support


### What this PR does / why we need it?
Improve the test coverage

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes


