### PR TITLE
Calling reset metric when the SL is not been sent due to it was sent already

### DIFF
--- a/pkg/handlers/webhookreceiver.go
+++ b/pkg/handlers/webhookreceiver.go
@@ -125,6 +125,7 @@ func (h *WebhookReceiverHandler) processAlert(alert template.Alert, mnl *oav1alp
 			log.WithFields(log.Fields{"notification": notification.Name,
 				LogFieldResendInterval: notification.ResendWait,
 			}).Info("not sending a notification as one was already sent recently")
+			metrics.ResetMetric(metrics.MetricResponseFailure)
 		} else {
 			log.WithFields(log.Fields{"notification": notification.Name}).Info("not sending a resolve notification if it was not firing or resolved body is empty")
 			s, err := managedNotifications.Status.GetNotificationRecord(notification.Name)

--- a/pkg/handlers/webhookrhobsreceiver.go
+++ b/pkg/handlers/webhookrhobsreceiver.go
@@ -192,6 +192,7 @@ func (h *WebhookRHOBSReceiverHandler) processFiringAlert(alert template.Alert, m
 		log.WithFields(log.Fields{"notification": fn.Name,
 			LogFieldResendInterval: fn.ResendWait,
 		}).Info("not sending a notification as one was already sent recently")
+		metrics.ResetMetric(metrics.MetricResponseFailure)
 		return nil
 	}
 


### PR DESCRIPTION
…already

### What type of PR is this?
bug


### What this PR does / why we need it?

OCMAgentResponseFailureServiceLogsSRE alert doesn't get reset for an alert which was already sent. This looks like a corner case where, service logs was sent to OCM but a network failure has caused the OCM agent to think that it failed to send the SL. 
PR changes will reset the metric when OCM-agen identifies when the SL was already sent for the firing alert. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-28946 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

