### PR TITLE
change base image to ubi8-minimal:8.10-1255

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.10-22
+FROM registry.access.redhat.com/ubi8-minimal:8.10-1255
 
 LABEL io.openshift.managed.name="ocm-agent" \
   io.openshift.managed.description="Agent to interact with OCM on managed clusters"


### PR DESCRIPTION
### What type of PR is this?
_(bug)_
```
panic: opensslcrypto: can't initialize OpenSSL : openssl: can't retrieve OpenSSL version

goroutine 1 [running]:
crypto/internal/backend.init.0()
        /usr/local/go/src/crypto/internal/backend/openssl.go:65 +0x299
```

### What this PR does / why we need it?
Change the base image having openssl pkg

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OSD-30088](https://issues.redhat.com/browse/OSD-30088)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

