### PR TITLE
Fixing lint errors came accross with go version 1.23.8

### DIFF
--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -14,24 +14,25 @@ func TestNewCmdRoot(t *testing.T) {
 
 	if rootCmd == nil {
 		t.Fatal("NewCmdRoot returned nil")
-	}
+	} else {
 
-	if rootCmd.Use != "ocm-agent" {
-		t.Errorf("Expected command Use to be 'ocm-agent', got %s", rootCmd.Use)
-	}
+		if rootCmd.Use != "ocm-agent" {
+			t.Errorf("Expected command Use to be 'ocm-agent', got %s", rootCmd.Use)
+		}
 
-	expectedShort := "Command line tool for OCM Agent to talk to OCM services."
-	if rootCmd.Short != expectedShort {
-		t.Errorf("Expected command Short to be '%s', got %s", expectedShort, rootCmd.Short)
-	}
+		expectedShort := "Command line tool for OCM Agent to talk to OCM services."
+		if rootCmd.Short != expectedShort {
+			t.Errorf("Expected command Short to be '%s', got %s", expectedShort, rootCmd.Short)
+		}
 
-	expectedLong := "Command line tool for OCM Agent to talk to OCM services."
-	if rootCmd.Long != expectedLong {
-		t.Errorf("Expected command Long to be '%s', got %s", expectedLong, rootCmd.Long)
-	}
+		expectedLong := "Command line tool for OCM Agent to talk to OCM services."
+		if rootCmd.Long != expectedLong {
+			t.Errorf("Expected command Long to be '%s', got %s", expectedLong, rootCmd.Long)
+		}
 
-	if !rootCmd.DisableAutoGenTag {
-		t.Error("Expected DisableAutoGenTag to be true")
+		if !rootCmd.DisableAutoGenTag {
+			t.Error("Expected DisableAutoGenTag to be true")
+		}
 	}
 }
 

--- a/pkg/cli/serve/serve_test.go
+++ b/pkg/cli/serve/serve_test.go
@@ -17,22 +17,22 @@ func TestNewServeCmd(t *testing.T) {
 
 	if cmd == nil {
 		t.Fatal("NewServeCmd returned nil")
-	}
+	} else {
+		if cmd.Use != "serve" {
+			t.Errorf("Expected command Use to be 'serve', got %s", cmd.Use)
+		}
 
-	if cmd.Use != "serve" {
-		t.Errorf("Expected command Use to be 'serve', got %s", cmd.Use)
-	}
+		if cmd.Short != "Starts the OCM Agent server" {
+			t.Errorf("Expected command Short to be 'Starts the OCM Agent server', got %s", cmd.Short)
+		}
 
-	if cmd.Short != "Starts the OCM Agent server" {
-		t.Errorf("Expected command Short to be 'Starts the OCM Agent server', got %s", cmd.Short)
-	}
+		if !strings.Contains(cmd.Long, "Start the OCM Agent server") {
+			t.Errorf("Expected command Long to contain 'Start the OCM Agent server', got %s", cmd.Long)
+		}
 
-	if !strings.Contains(cmd.Long, "Start the OCM Agent server") {
-		t.Errorf("Expected command Long to contain 'Start the OCM Agent server', got %s", cmd.Long)
-	}
-
-	if !strings.Contains(cmd.Example, "ocm-agent serve") {
-		t.Errorf("Expected command Example to contain 'ocm-agent serve', got %s", cmd.Example)
+		if !strings.Contains(cmd.Example, "ocm-agent serve") {
+			t.Errorf("Expected command Example to contain 'ocm-agent serve', got %s", cmd.Example)
+		}
 	}
 }
 


### PR DESCRIPTION
### What type of PR is this?
_bug_


### What this PR does / why we need it?

Fixed below lint errors when using go1.23.8
```
$ make lint 
test/e2e/project.mk:31: warning: overriding recipe for target 'e2e-image-build-push'
boilerplate/openshift/golang-osd-e2e/standard.mk:70: warning: ignoring old recipe for target 'e2e-image-build-push'
/home/cabeywar/go/bin/bin/golangci-lint run --timeout=5m
pkg/cli/serve/serve_test.go:22:9: SA5011: possible nil pointer dereference (staticcheck)
	if cmd.Use != "serve" {
	       ^
pkg/cli/serve/serve_test.go:18:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if cmd == nil {
	   ^
pkg/cli/root_test.go:19:13: SA5011: possible nil pointer dereference (staticcheck)
	if rootCmd.Use != "ocm-agent" {
	           ^
pkg/cli/root_test.go:15:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if rootCmd == nil {
	   ^
make: *** [Makefile:125: lint] Error 1

```


