### PR TITLE
SREP-911 create network policy inside the code

### DIFF
--- a/test/e2e/e2e-personal-job.yaml
+++ b/test/e2e/e2e-personal-job.yaml
@@ -21,6 +21,9 @@ rules:
 - apiGroups: ["ocmagent.managed.openshift.io"]
   resources: ["managednotifications", "managedfleetnotifications", "managedfleetnotificationrecords"]
   verbs: ["get", "list", "create", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies"]
+  verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -34,26 +37,6 @@ subjects:
 - kind: ServiceAccount
   name: ocm-agent-e2e-sa
   namespace: openshift-ocm-agent-operator
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: ocm-agent-allow-e2e-test
-  namespace: openshift-ocm-agent-operator
-spec:
-  podSelector:
-    matchLabels:
-      app: ocm-agent
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: openshift-ocm-agent-operator
-      podSelector:
-        matchLabels:
-          app: ocm-agent-e2e
 ---
 apiVersion: batch/v1
 kind: Job

--- a/test/e2e/e2e-template.yml
+++ b/test/e2e/e2e-template.yml
@@ -31,25 +31,6 @@ parameters:
   - name: LOG_BUCKET
     value: 'osde2e-logs'
 objects:
-  - apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: ocm-agent-allow-e2e-test
-      namespace: openshift-ocm-agent-operator
-    spec:
-      podSelector:
-        matchLabels:
-          app: osde2e-ocm-agent-${IMAGE_TAG}-${JOBID}
-      policyTypes:
-      - Ingress
-      ingress:
-      - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-ocm-agent-operator
-          podSelector:
-            matchLabels:
-              app: ocm-agent-e2e
   - apiVersion: batch/v1
     kind: Job
     metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_


### What this PR does / why we need it?
The network policy was setup to all traffic from openshift-ocm-agent-operator namespace. But e2e job actually is running on a different namespace which caused network traffic timeout.
This PR changes the networkpolicy configure to allow traffic from all namespaces 

### Which Jira/Github issue(s) this PR fixes?
Fix e2e test failure.
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

