### PR TITLE
Adding E2E tests for HCP and updating README

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,8 @@ const (
 	ExternalClusterID string = "cluster-id"
 	// FleetMode represents if ocm-agent is going to run in default OSD/ROSA mode or HyperShift mode
 	FleetMode string = "fleet-mode"
+	// TestMode represents if ocm-agent is going to run in fleet mode for testing purposes
+	TestMode string = "test-mode"
 	// OCMClientID represents the OCM Client ID that will be used for testing fleet-mode run
 	OCMClientID string = "ocm-client-id"
 	// OCMClientSecret represents the OCM Client ID that will be used for testing fleet-mode run

--- a/pkg/consts/test/test.go
+++ b/pkg/consts/test/test.go
@@ -1,17 +1,26 @@
 package test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"time"
 
+	. "github.com/onsi/gomega"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ocmagentv1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
 	"github.com/prometheus/alertmanager/template"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 
 	"github.com/openshift/ocm-agent/pkg/consts"
 )
@@ -97,6 +106,37 @@ var (
 		},
 	}
 )
+
+// E2E Test Structs
+// Alert represents the structure of an alert sent to OCM Agent
+type Alert struct {
+	Status                           string            `json:"status"`
+	Labels                           map[string]string `json:"labels"`
+	Annotations                      map[string]string `json:"annotations"`
+	StartsAt                         string            `json:"startsAt"`
+	EndsAt                           string            `json:"endsAt"`
+	GeneratorURL                     string            `json:"generatorURL"`
+	ManagedFleetNotificationTemplate string            `json:"managedFleetNotificationTemplate"`
+	MCClusterID                      string            `json:"_mc_id"`
+	ClusterID                        string            `json:"_id"`
+	Source                           string            `json:"source"`
+}
+
+// AlertPayload represents the structure of an alert sent to OCM Agent
+type AlertPayload struct {
+	Receiver          string            `json:"receiver"`
+	Status            string            `json:"status"`
+	Alerts            []Alert           `json:"alerts"`
+	GroupLabels       map[string]string `json:"groupLabels"`
+	CommonLabels      map[string]string `json:"commonLabels"`
+	CommonAnnotations map[string]string `json:"commonAnnotations"`
+	ExternalURL       string            `json:"externalURL"`
+}
+
+// AlertResponse represents the response from the OCM Agent
+type AlertResponse struct {
+	Status string `json:"status"`
+}
 
 func NewFleetNotification() ocmagentv1alpha1.FleetNotification {
 	return ocmagentv1alpha1.FleetNotification{
@@ -228,4 +268,305 @@ func NewTestServiceLog(summary, desc, clusterUUID string, severity ocmagentv1alp
 	sl, _ := slBuilder.Build()
 
 	return sl
+}
+
+// E2E Test Helper Functions
+
+// CreateNetworkPolicy creates a network policy which allow all traffic to ocm-agent for testing.
+func CreateNetworkPolicy(ctx context.Context, client *resources.Resources, networkPolicyName, namespace string) error {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "ocm-agent",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{},
+			},
+		},
+	}
+	err := client.Create(ctx, networkPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to create network policy: %v", err)
+	}
+
+	return nil
+}
+
+// CreateDefaultNotification creates a managed notification CRD for testing
+func CreateDefaultNotification(ctx context.Context, k8sClient crClient.Client, namespace, ocmAgentManagedNotification, testNotificationName string) error {
+	defaultNotification := &ocmagentv1alpha1.ManagedNotification{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ManagedNotification",
+			APIVersion: "ocmagent.managed.openshift.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ocmAgentManagedNotification,
+			Namespace: namespace,
+		},
+		Spec: ocmagentv1alpha1.ManagedNotificationSpec{
+			Notifications: []ocmagentv1alpha1.Notification{
+				{
+					Name:         testNotificationName,
+					ResendWait:   24,
+					ResolvedDesc: `Your cluster's ElasticSearch deployment is detected as being at safe disk consumption levels and no additional action on this issue is required.`,
+					ActiveDesc:   `Your cluster requires you to take action as its ElasticSearch cluster logging deployment has been detected as reaching a high disk usage threshold.`,
+					Severity:     "Info",
+					Summary:      "ElasticSearch reaching disk capacity",
+				},
+				{
+					Name:         "ParallelAlert_1",
+					ResendWait:   24,
+					ResolvedDesc: `Parallel Alert1 has been resolved`,
+					ActiveDesc:   `Your cluster requires you to take action as Parallel Alert1 is firing.`,
+					Severity:     "Info",
+					Summary:      "Test Parallel Alert 1",
+				},
+				{
+					Name:         "ParallelAlert_2",
+					ResendWait:   24,
+					ResolvedDesc: `Parallel Alert2 has been resolved`,
+					ActiveDesc:   `Your cluster requires you to take action as Parallel Alert1 is firing.`,
+					Severity:     "Info",
+					Summary:      "Test Parallel Alert 2",
+				},
+			},
+		},
+	}
+	err := k8sClient.Create(ctx, defaultNotification)
+	if err != nil {
+		return fmt.Errorf("failed to create default notification: %v", err)
+	}
+	return nil
+}
+
+// CreateSingleAlert creates an alert payload similar to the shell script create-alert.sh
+func CreateSingleAlert(alertStatus, alertName, managedNotificationTemplate string) AlertPayload {
+	today := time.Now().UTC().Format("2006-01-02")
+
+	return AlertPayload{
+		Receiver: "ocmagent",
+		Status:   alertStatus,
+		Alerts: []Alert{
+			{
+				Status: alertStatus,
+				Labels: map[string]string{
+					"alertname":                     alertName,
+					"alertstate":                    alertStatus,
+					"namespace":                     "openshift-monitoring",
+					"openshift_io_alert_source":     "platform",
+					"prometheus":                    "openshift-monitoring/k8s",
+					"send_managed_notification":     "true",
+					"managed_notification_template": managedNotificationTemplate,
+					"severity":                      "info",
+				},
+				Annotations: map[string]string{
+					"description": "",
+				},
+				StartsAt:     today + "T00:00:00Z",
+				EndsAt:       "0001-01-01T00:00:00Z",
+				GeneratorURL: "",
+			},
+		},
+		GroupLabels:       map[string]string{},
+		CommonLabels:      map[string]string{},
+		CommonAnnotations: map[string]string{},
+		ExternalURL:       "",
+	}
+}
+
+// CreateBiAlert creates an alert payload with two alerts
+func CreateBiAlert(alertStatus, alertName, managedNotificationTemplate string) AlertPayload {
+	today := time.Now().UTC().Format("2006-01-02")
+
+	return AlertPayload{
+		Receiver: "ocmagent",
+		Status:   alertStatus,
+		Alerts: []Alert{
+			{
+				Status: alertStatus,
+				Labels: map[string]string{
+					"alertname":                     alertName + "_1",
+					"alertstate":                    alertStatus,
+					"namespace":                     "openshift-monitoring",
+					"openshift_io_alert_source":     "platform",
+					"prometheus":                    "openshift-monitoring/k8s",
+					"send_managed_notification":     "true",
+					"managed_notification_template": managedNotificationTemplate + "_1",
+					"severity":                      "info",
+				},
+				Annotations: map[string]string{
+					"description": "",
+				},
+				StartsAt:     today + "T00:00:00Z",
+				EndsAt:       "0001-01-01T00:00:00Z",
+				GeneratorURL: "",
+			},
+			{
+				Status: alertStatus,
+				Labels: map[string]string{
+					"alertname":                     alertName + "_2",
+					"alertstate":                    alertStatus,
+					"namespace":                     "openshift-monitoring",
+					"openshift_io_alert_source":     "platform",
+					"prometheus":                    "openshift-monitoring/k8s",
+					"send_managed_notification":     "true",
+					"managed_notification_template": managedNotificationTemplate + "_2",
+					"severity":                      "info",
+				},
+				Annotations: map[string]string{
+					"description": "",
+				},
+				StartsAt:     today + "T00:00:00Z",
+				EndsAt:       "0001-01-01T00:00:00Z",
+				GeneratorURL: "",
+			},
+		},
+		GroupLabels:       map[string]string{},
+		CommonLabels:      map[string]string{},
+		CommonAnnotations: map[string]string{},
+		ExternalURL:       "",
+	}
+}
+
+// PostAlert sends an alert to the OCM Agent similar to post-alert.sh
+func PostAlert(ctx context.Context, alert AlertPayload, httpClient *http.Client, ocmAgentURL string) error {
+	alertJSON, err := json.Marshal(alert)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alert: %v", err)
+	}
+
+	resp, err := httpClient.Post(
+		fmt.Sprintf("%s/alertmanager-receiver", ocmAgentURL),
+		"application/json",
+		bytes.NewBuffer(alertJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to post alert: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var alertResponse AlertResponse
+	if err := json.NewDecoder(resp.Body).Decode(&alertResponse); err != nil {
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if alertResponse.Status != "ok" {
+		return fmt.Errorf("alert posting failed with status: %s", alertResponse.Status)
+	}
+
+	return nil
+}
+
+// GetServiceLogCount gets the count of service logs for a cluster
+func GetServiceLogCount(ctx context.Context, clusterUUID string, ocmConnection *sdk.Connection) (int, error) {
+	serviceLogsClient := ocmConnection.ServiceLogs().V1()
+
+	response, err := serviceLogsClient.Clusters().ClusterLogs().List().
+		Parameter("cluster_uuid", clusterUUID).
+		Send()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get service logs: %v", err)
+	}
+
+	return response.Total(), nil
+}
+
+// CheckServiceLogCount verifies the service log count matches expectations
+func CheckServiceLogCount(ctx context.Context, clusterUUID string, preCount, expectedNew int, ocmConnection *sdk.Connection) {
+	expectedTotal := preCount + expectedNew
+	actualCount, err := GetServiceLogCount(ctx, clusterUUID, ocmConnection)
+	Expect(err).Should(BeNil(), "failed to get service log count")
+	Expect(actualCount).Should(Equal(expectedTotal),
+		fmt.Sprintf("Expected SL count: %d, Got SL count: %d", expectedTotal, actualCount))
+}
+
+// CreateFleetAlert creates an alert payload for fleet mode
+func CreateFleetAlert(alertStatus, alertName, managementClusterID, managedFleetNotificationTemplate, externalClusterID string) AlertPayload {
+	today := time.Now().UTC().Format("2006-01-02")
+
+	return AlertPayload{
+		Receiver: "ocmagent",
+		Status:   alertStatus,
+		Alerts: []Alert{
+			{
+				Status: alertStatus,
+				Labels: map[string]string{
+					"alertname":                     alertName,
+					"alertstate":                    alertStatus,
+					"namespace":                     "openshift-monitoring",
+					"openshift_io_alert_source":     "platform",
+					"prometheus":                    "openshift-monitoring/k8s",
+					"send_managed_notification":     "true",
+					"managed_notification_template": managedFleetNotificationTemplate,
+					"severity":                      "info",
+					"_mc_id":                        managementClusterID,
+					"_id":                           externalClusterID,
+					"source":                        "MC",
+				},
+				Annotations: map[string]string{
+					"description": "",
+				},
+				StartsAt:     today + "T00:00:00Z",
+				EndsAt:       "0001-01-01T00:00:00Z",
+				GeneratorURL: "",
+			},
+		},
+		GroupLabels:       map[string]string{},
+		CommonLabels:      map[string]string{},
+		CommonAnnotations: map[string]string{},
+		ExternalURL:       "",
+	}
+}
+
+// GetLimitedSupportCount gets the count of limited support records for a cluster
+func GetLimitedSupportCount(ctx context.Context, internalClusterID string, ocmConnection *sdk.Connection) (int, error) {
+	limitedSupportClient := ocmConnection.ClustersMgmt().V1()
+	response, err := limitedSupportClient.Clusters().Cluster(internalClusterID).LimitedSupportReasons().List().
+		Send()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get limited support count: %v", err)
+	}
+	return response.Total(), nil
+}
+
+// CheckLimitedSupportCount verifies the limited support count matches expectations
+func CheckLimitedSupportCount(ctx context.Context, internalClusterID string, expectedTotal int, ocmConnection *sdk.Connection) {
+	actualCount, err := GetLimitedSupportCount(ctx, internalClusterID, ocmConnection)
+	Expect(err).Should(BeNil(), "failed to get limited support count")
+	Expect(actualCount).Should(Equal(expectedTotal),
+		fmt.Sprintf("Expected limited support count: %d, Got limited support count: %d", expectedTotal, actualCount))
+}
+
+// GetMfnriCount gets the count of firing notification sent for a cluster
+func GetMfnriCount(ctx context.Context, mcClusterID string, k8sClient crClient.Client) (int, int, error) {
+	mFNRRecord := &ocmagentv1alpha1.ManagedFleetNotificationRecord{}
+	err := k8sClient.Get(ctx, crClient.ObjectKey{
+		Name:      mcClusterID,
+		Namespace: "openshift-ocm-agent-operator"},
+		mFNRRecord)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get managed-fleet-notification-records: %v", err)
+	}
+	return mFNRRecord.Status.NotificationRecordByName[0].NotificationRecordItems[0].FiringNotificationSentCount,
+		mFNRRecord.Status.NotificationRecordByName[0].NotificationRecordItems[0].ResolvedNotificationSentCount,
+		nil
+}
+
+// CheckMfnriCount compares firing notification sent count with expected count for a cluster
+func CheckMfnriCount(ctx context.Context, mcClusterID string, expectedFiringCount int, expectedResolvedCount int, k8sClient crClient.Client) {
+	currentFiringCount, currentResolvedCount, err := GetMfnriCount(ctx, mcClusterID, k8sClient)
+	Expect(err).Should(BeNil(), "failed to get managed-fleet-notification-record count")
+	Expect(currentFiringCount).Should(Equal(expectedFiringCount),
+		fmt.Sprintf("Expected firing notification sent count: %d, Got firing notification sent count: %d", expectedFiringCount, currentFiringCount))
+	Expect(currentResolvedCount).Should(Equal(expectedResolvedCount),
+		fmt.Sprintf("Expected resolved notification sent count: %d, Got resolved notification sent count: %d", expectedResolvedCount, currentResolvedCount))
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -31,6 +31,8 @@ func NewClient() (client.Client, error) {
 
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
+		&oav1alpha1.OcmAgent{},
+		&oav1alpha1.OcmAgentList{},
 		&oav1alpha1.ManagedNotification{},
 		&oav1alpha1.ManagedNotificationList{},
 		&oav1alpha1.ManagedFleetNotification{},

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -2,6 +2,7 @@ package ocm
 
 import (
 	"fmt"
+
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	log "github.com/sirupsen/logrus"
 )

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,37 +1,107 @@
-## Locally running e2e test suite
-When updating your operator it's beneficial to add e2e tests for new functionality AND ensure existing functionality is not breaking using e2e tests. 
-To do this, following steps are recommended
+# OCM Agent E2E Test Suite
 
-1. Run "make e2e-binary-build"  to make sure e2e tests build 
-2. Deploy your new version of operator in a test cluster
-3. Run "go install github.com/onsi/ginkgo/ginkgo@latest"
-4. Get kubeadmin credentials from your cluster using 
+This directory contains the end-to-end (E2E) test suite for the OCM Agent service. The test suite has been recently refactored for better organization, maintainability, and readability.
 
-ocm get /api/clusters_mgmt/v1/clusters/(cluster-id)/credentials | jq -r .kubeconfig > /(path-to)/kubeconfig
+## Test Structure Improvements
 
-5. Run test suite using 
- 
-DISABLE_JUNIT_REPORT=true KUBECONFIG=/(path-to)/kubeconfig  ./(path-to)/bin/ginkgo  --tags=osde2e -v test/e2e
+### Recent Refactoring
 
-## ocm-agent e2e test for local test
-When running tests locally against a remote cluster, you will need to use `oc port-forward` to make the ocm-agent available to your local test environment.
+The test suite has been significantly improved with the following changes:
 
-First, find the name of the `ocm-agent` pod:
+- **Common Test Utilities**: Shared test functions and structs have been moved to `pkg/consts/test/test.go` for better reusability
+- **Standardized Test Descriptions**: All `ginkgo.By` descriptions now follow a uniform format:
+  - `Setup:` for initialization and configuration steps
+  - `Step X:` for test execution steps  
+  - `Cleanup:` for teardown operations
+- **Improved Readability**: Test files are now more readable with consistent formatting and better organization
+
+### Test Categories
+
+The E2E test suite includes three main test categories:
+
+1. **OcmAgentCommon** - Basic deployment and health check tests
+2. **OcmAgentClassic** - Traditional OCM Agent functionality testing
+3. **OcmAgentHCP** - Fleet mode testing for multi-cluster management
+
+## Prerequisites
+
+Before running the E2E tests, ensure you have:
+
+- Go 1.19+ installed
+- Access to a Kubernetes cluster with OCM Agent deployed
+- OCM credentials (token or client ID/secret)
+- `ginkgo` test runner installed
+
+## Installation
+
+Install the required dependencies:
+
 ```bash
-oc get pods -n openshift-ocm-agent-operator -l app=ocm-agent
+# Install Ginkgo test runner
+go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+# Build the E2E test binary
+make e2e-binary-build
 ```
 
-Use the pod name to set up port forwarding:
+## Running Tests Locally
+
+### Basic Setup
+
+1. **Build the test binary**:
+   ```bash
+   make e2e-binary-build
+   ```
+
+2. **Get cluster credentials**:
+   ```bash
+   ocm get /api/clusters_mgmt/v1/clusters/$INTERNAL_CLUSTERID/credentials | jq -r .kubeconfig > /path/to/kubeconfig
+   ```
+
+3. **Run the complete test suite**:
+   ```bash
+   DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ./bin/ginkgo --tags=osde2e -v test/e2e
+   ```
+
+### Running Specific Test Categories
+
+#### Common Tests (Basic Deployment)
 ```bash
-oc -n openshift-ocm-agent-operator port-forward <ocm-agent-pod-name> 8081:8081
+DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ginkgo run --tags=osde2e -vv --label-filter="OcmAgentCommon" test/e2e/
 ```
 
-Run the tests with the `OCM_AGENT_URL` environment variable set:
+#### Classic Mode Tests
 ```bash
-export OCM_TOKEN=$(ocm token)
-OCM_AGENT_URL=http://localhost:8081 DISABLE_JUNIT_REPORT=true KUBECONFIG=/(path-to)/kubeconfig ./bin/ginkgo --tags=osde2e -v test/e2e
+DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ginkgo run --tags=osde2e -vv --label-filter="OcmAgentClassic" test/e2e/
 ```
 
+#### Fleet Mode Tests
+```bash
+DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ginkgo run --tags=osde2e -vv --label-filter="OcmAgentHCP" test/e2e/
+```
+
+### Running with Port Forwarding
+
+When testing against a remote cluster, use port forwarding to access the OCM Agent service:
+
+1. **Find the OCM Agent pod**:
+   ```bash
+   oc get pods -n openshift-ocm-agent-operator -l app=ocm-agent
+   ```
+
+2. **Set up port forwarding**:
+   ```bash
+   oc -n openshift-ocm-agent-operator port-forward <ocm-agent-pod-name> 8081:8081
+   ```
+
+3. **Run tests with local URL**:
+   ```bash
+   OCM_TOKEN=$(ocm token) OCM_AGENT_URL=http://localhost:8081 DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ./bin/ginkgo --tags=osde2e -v test/e2e
+   ```
+
+### Architecture Diagram
+
+```
                    ┌──────────────────────┐
                    │ Kubernetes Cluster   │
 ┌─────────────────┐│    ┌───────────────┐ │
@@ -45,25 +115,48 @@ OCM_AGENT_URL=http://localhost:8081 DISABLE_JUNIT_REPORT=true KUBECONFIG=/(path-
            └──────────────────────┘       │
                    │                      │
                    └──────────────────────┘
-
-## ocm-agent e2e image test for personal cluster
-
-The e2e image can be executed in existing cluster. This will be similar to CI environment except provisioning a new cluster and ocm connection setup.
-Several environment varibles should be set before run the e2e image test.
-```
-export TEST_IMAGE="YOUR TEST IMAGE in quay.io, eg quay.io/tkong-ocm/ocm-agent-e2e"
-export IMAGE_TAG="tag of the image, eg latest"
-export OCM_E2E_TOKEN=$(ocm token)
-export AWS_ACCESS_KEY_ID="aws access key id"
-export AWS_SECRET_ACCESS_KEY="aws access key"
-export REGION="Same region as testing cluster"
-export CLUSTER_ID="Testing cluster ID"
-export OSD_ENV="stage or int"
-envsubst < ./test/e2e/e2e-image-job.yaml | oc apply --as backplane-cluster-admin -f -
 ```
 
-### Debugging ocm-agent e2e image test
-The workflow for e2e test image is
+## Fleet Mode Testing
+
+### Running Fleet Mode Tests Locally
+
+1. **Build and run OCM Agent in fleet mode**:
+   ```bash
+   ./test/build-and-run.sh ${CLUSTERNAME} --fleet-mode
+   ```
+
+2. **Run fleet mode tests**:
+   ```bash
+   OCM_TOKEN=$(ocm token) TESTING_MODE="FLEET" OCM_AGENT_URL=http://localhost:8081 DISABLE_JUNIT_REPORT=true KUBECONFIG=/path/to/kubeconfig ./bin/ginkgo --tags=osde2e -v test/e2e
+   ```
+
+## E2E Image Testing
+
+### Running in Cluster
+
+The E2E tests can be executed as a job within an existing cluster:
+
+1. **Set environment variables**:
+   ```bash
+   export TEST_IMAGE="quay.io/your-org/ocm-agent-e2e"
+   export IMAGE_TAG="latest"
+   export OCM_E2E_TOKEN=$(ocm token)
+   export AWS_ACCESS_KEY_ID="your-access-key"
+   export AWS_SECRET_ACCESS_KEY="your-secret-key"
+   export REGION="us-east-1"
+   export CLUSTER_ID="your-cluster-id"
+   export OSD_ENV="stage"
+   ```
+
+2. **Deploy the test job**:
+   ```bash
+   envsubst < ./test/e2e/e2e-image-job.yaml | oc apply --as backplane-cluster-admin -f -
+   ```
+
+### Debugging E2E Image Tests
+
+The E2E image test workflow:
 
 ```mermaid
 flowchart LR
@@ -74,22 +167,68 @@ end
 A[osde2e image job] --> B[osd e2e image pod] --> N
 ```
 
-So the actual e2e test is executed in ocm-agent e2e test pod.
-Using command `oc get namespace | grep osde2e` to find the executor namespace. The pod log can be inspected to see the test results. eg
+To debug:
+
+1. **Find the executor namespace**:
+   ```bash
+   oc get namespace | grep osde2e
+   ```
+
+2. **Check test logs**:
+   ```bash
+   oc -n osde2e-executor-<id> logs executor-<id> --as backplane-cluster-admin
+   ```
+
+3. **Debug with detailed output**:
+   ```bash
+   oc -n osde2e-executor-<id> exec -it executor-<id> -- /e2e.test --ginkgo.vv --ginkgo.trace --ginkgo.fail-on-empty
+   ```
+
+## Test Development Guidelines
+
+### Adding New Tests
+
+When adding new E2E tests:
+
+1. **Use common utilities**: Leverage functions from `pkg/consts/test/test.go`
+2. **Follow naming conventions**: Use descriptive test names and labels
+3. **Use standardized descriptions**: Follow the `Setup:`, `Step X:`, `Cleanup:` format
+4. **Add appropriate labels**: Use `OcmAgentCommon`, `OcmAgentClassic`, or `OcmAgentHCP` labels
+
+### Test Organization
+
+- **Test files**: Place in `test/e2e/` directory
+- **Common utilities**: Add to `pkg/consts/test/test.go`
+- **Test data**: Use `test/files/` for test fixtures
+- **Manifests**: Use `test/manifests/` for test resources
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Tests skipped**: Check OCM credentials and cluster connectivity
+2. **Port forwarding issues**: Ensure the OCM Agent pod is running
+3. **Build failures**: Verify Go version and dependencies
+
+### Debug Commands
+
+```bash
+# Validate test structure
+ginkgo outline test/e2e/ocm_agent_tests.go
+
+# List available test labels
+ginkgo labels test/e2e/
+
+# Run with maximum verbosity
+ginkgo run --tags=osde2e -vv --trace test/e2e/
 ```
-oc -n osde2e-executor-0409i logs executor-cqf92-f7w5p --as backplane-cluster-admin
 
-Running Suite: Ocm Agent - /
-============================
-Random Seed: 1756259203
+## Contributing
 
-Will run 3 of 3 specs
-SSS
+When contributing to the E2E test suite:
 
-Ran 0 of 3 Specs in 0.024 seconds
-SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 3 Skipped
-PASS
-```
-In this example, all the test are skipped. To figure more details, debug into the pod and execute command `/e2e.test --ginkgo.vv --ginkgo.trace --ginkgo.fail-on-empty` to run the tests again and check the detailed log.
-
-
+1. Ensure tests are comprehensive and cover edge cases
+2. Use the standardized test description format
+3. Leverage common test utilities when possible
+4. Add appropriate test labels for categorization
+5. Update this documentation when adding new test categories or procedures

--- a/test/e2e/ocm_agent_runner_test.go
+++ b/test/e2e/ocm_agent_runner_test.go
@@ -21,8 +21,18 @@ const (
 func TestOcmAgent(t *testing.T) {
 	RegisterFailHandler(Fail)
 	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	labelFilter := os.Getenv("GINKGO_LABEL_FILTER")
+	if labelFilter != "" {
+		suiteConfig.LabelFilter = labelFilter
+	}
+
+	if suiteConfig.LabelFilter == "" {
+		suiteConfig.LabelFilter = "OcmAgentCommon || OcmAgentClassic || OcmAgentHCP"
+	}
+
 	if _, ok := os.LookupEnv("DISABLE_JUNIT_REPORT"); !ok {
 		reporterConfig.JUnitReport = filepath.Join(testResultsDirectory, jUnitOutputFilename)
 	}
-	RunSpecs(t, "Ocm Agent", suiteConfig, reporterConfig)
+	RunSpecs(t, "Ocm Agent Suite", suiteConfig, reporterConfig)
 }

--- a/test/e2e/ocm_agent_tests.go
+++ b/test/e2e/ocm_agent_tests.go
@@ -4,80 +4,54 @@
 package osde2etests
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"time"
 
+	oav1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
+	"github.com/openshift/ocm-agent/pkg/k8s"
+	"github.com/openshift/ocm-agent/pkg/ocm"
+	testconst "github.com/openshift/ocm-agent/pkg/consts/test"
+
 	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 
-	// OCM-related imports
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	configv1 "github.com/openshift/api/config/v1"
-	oav1alpha1 "github.com/openshift/ocm-agent-operator/api/v1alpha1"
-	"github.com/openshift/ocm-agent/pkg/k8s"
-	"github.com/openshift/ocm-agent/pkg/ocm"
 )
-
-// AlertPayload represents the structure of an alert sent to OCM Agent
-type AlertPayload struct {
-	Receiver          string            `json:"receiver"`
-	Status            string            `json:"status"`
-	Alerts            []Alert           `json:"alerts"`
-	GroupLabels       map[string]string `json:"groupLabels"`
-	CommonLabels      map[string]string `json:"commonLabels"`
-	CommonAnnotations map[string]string `json:"commonAnnotations"`
-	ExternalURL       string            `json:"externalURL"`
-}
-
-// Alert represents a single alert in the payload
-type Alert struct {
-	Status       string            `json:"status"`
-	Labels       map[string]string `json:"labels"`
-	Annotations  map[string]string `json:"annotations"`
-	StartsAt     string            `json:"startsAt"`
-	EndsAt       string            `json:"endsAt"`
-	GeneratorURL string            `json:"generatorURL"`
-}
-
-// AlertResponse represents the response from OCM Agent
-type AlertResponse struct {
-	Status string `json:"Status"`
-}
 
 var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 
 	var (
 		client                      *resources.Resources
-		k8sClient                   crclient.Client
+		k8sClient                   crClient.Client
 		errorServer                 *httptest.Server
+		ocmConnection               *sdk.Connection
 		namespace                   = "openshift-ocm-agent-operator"
 		deploymentName              = "ocm-agent"
 		ocmAgentConfigMap           = "ocm-agent-cm"
-		ocmAgentFleetConfigMap      = "ocm-agent-fleet-cm"
 		ocmAgentManagedNotification = "sre-managed-notifications"
 		networkPolicyName           = "ocm-agent-allow-all-ingress"
 		testNotificationName        = "LoggingVolumeFillingUp"
 		clusterVersionName          = "version"
 		infrastructureName          = "cluster"
-		isFleetMode                 = false
+		shortSleepInterval          = 5 * time.Second  // 3 seconds
+		longSleepInterval           = 30 * time.Second // 30 seconds
 
 		// ConfigMap keys
 		clusterIDKey  = "clusterID"
@@ -90,242 +64,46 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		ocmAgentPodName   string
 		ocmBaseURL        string
 		ocmAgentURL       = "http://ocm-agent.openshift-ocm-agent-operator.svc:8081"
+		ocmAgentFleetURL  = "http://ocm-agent-fleet.openshift-ocm-agent-operator.svc:8081"
 		httpClient        = &http.Client{Timeout: 30 * time.Second}
 		externalClusterID string
 		internalClusterID string
-		ocmConnection     *sdk.Connection
 
 		deployments = []string{
 			deploymentName,
 			deploymentName + "-operator",
 		}
+		alertName = "LoggingVolumeFillingUpNotificationSRE"
 	)
-
-	// createNetworkpolicy creates a network policy which allow all traffic to ocm-agent for testing.
-	createNetworkPolicy := func(ctx context.Context) error {
-		networkPolicy := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      networkPolicyName,
-				Namespace: namespace,
-			},
-			Spec: networkingv1.NetworkPolicySpec{
-				PodSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app": "ocm-agent",
-					},
-				},
-				PolicyTypes: []networkingv1.PolicyType{
-					networkingv1.PolicyTypeIngress,
-				},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{
-					{},
-				},
-			},
-		}
-		err := client.Create(ctx, networkPolicy)
-		if err != nil {
-			return fmt.Errorf("failed to create network policy: %v", err)
-		}
-
-		return nil
-	}
-
-	// createDefaultNotification creates a managed notification CRD for testing
-	createDefaultNotification := func(ctx context.Context) error {
-		defaultNotification := &oav1alpha1.ManagedNotification{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ManagedNotification",
-				APIVersion: "ocmagent.managed.openshift.io/v1alpha1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ocmAgentManagedNotification,
-				Namespace: namespace,
-			},
-			Spec: oav1alpha1.ManagedNotificationSpec{
-				Notifications: []oav1alpha1.Notification{
-					{
-						Name:         testNotificationName,
-						ResendWait:   24,
-						ResolvedDesc: `Your cluster's ElasticSearch deployment is detected as being at safe disk consumption levels and no additional action on this issue is required.`,
-						ActiveDesc:   `Your cluster requires you to take action as its ElasticSearch cluster logging deployment has been detected as reaching a high disk usage threshold.`,
-						Severity:     "Info",
-						Summary:      "ElasticSearch reaching disk capacity",
-					},
-					{
-						Name:         "ParallelAlert_1",
-						ResendWait:   24,
-						ResolvedDesc: `Parallel Alert1 has been resolved`,
-						ActiveDesc:   `Your cluster requires you to take action as Parallel Alert1 is firing.`,
-						Severity:     "Info",
-						Summary:      "Test Parallel Alert 1",
-					},
-					{
-						Name:         "ParallelAlert_2",
-						ResendWait:   24,
-						ResolvedDesc: `Parallel Alert2 has been resolved`,
-						ActiveDesc:   `Your cluster requires you to take action as Parallel Alert1 is firing.`,
-						Severity:     "Info",
-						Summary:      "Test Parallel Alert 2",
-					},
-				},
-			},
-		}
-		err := k8sClient.Create(ctx, defaultNotification)
-		if err != nil {
-			return fmt.Errorf("failed to create default notification: %v", err)
-		}
-		return nil
-	}
-
-	// createAlert creates an alert payload similar to the shell script create-alert.sh
-	createSingleAlert := func(alertStatus, alertName, managedNotificationTemplate string) AlertPayload {
-		today := time.Now().UTC().Format("2006-01-02")
-
-		return AlertPayload{
-			Receiver: "ocmagent",
-			Status:   alertStatus,
-			Alerts: []Alert{
-				{
-					Status: alertStatus,
-					Labels: map[string]string{
-						"alertname":                     alertName,
-						"alertstate":                    alertStatus,
-						"namespace":                     "openshift-monitoring",
-						"openshift_io_alert_source":     "platform",
-						"prometheus":                    "openshift-monitoring/k8s",
-						"send_managed_notification":     "true",
-						"managed_notification_template": managedNotificationTemplate,
-						"severity":                      "info",
-					},
-					Annotations: map[string]string{
-						"description": "",
-					},
-					StartsAt:     today + "T00:00:00Z",
-					EndsAt:       "0001-01-01T00:00:00Z",
-					GeneratorURL: "",
-				},
-			},
-			GroupLabels:       map[string]string{},
-			CommonLabels:      map[string]string{},
-			CommonAnnotations: map[string]string{},
-			ExternalURL:       "",
-		}
-	}
-
-	createBiAlert := func(alertStatus, alertName, managedNotificationTemplate string) AlertPayload {
-		today := time.Now().UTC().Format("2006-01-02")
-
-		return AlertPayload{
-			Receiver: "ocmagent",
-			Status:   alertStatus,
-			Alerts: []Alert{
-				{
-					Status: alertStatus,
-					Labels: map[string]string{
-						"alertname":                     alertName + "_1",
-						"alertstate":                    alertStatus,
-						"namespace":                     "openshift-monitoring",
-						"openshift_io_alert_source":     "platform",
-						"prometheus":                    "openshift-monitoring/k8s",
-						"send_managed_notification":     "true",
-						"managed_notification_template": managedNotificationTemplate + "_1",
-						"severity":                      "info",
-					},
-					Annotations: map[string]string{
-						"description": "",
-					},
-					StartsAt:     today + "T00:00:00Z",
-					EndsAt:       "0001-01-01T00:00:00Z",
-					GeneratorURL: "",
-				},
-				{
-					Status: alertStatus,
-					Labels: map[string]string{
-						"alertname":                     alertName + "_2",
-						"alertstate":                    alertStatus,
-						"namespace":                     "openshift-monitoring",
-						"openshift_io_alert_source":     "platform",
-						"prometheus":                    "openshift-monitoring/k8s",
-						"send_managed_notification":     "true",
-						"managed_notification_template": managedNotificationTemplate + "_2",
-						"severity":                      "info",
-					},
-					Annotations: map[string]string{
-						"description": "",
-					},
-					StartsAt:     today + "T00:00:00Z",
-					EndsAt:       "0001-01-01T00:00:00Z",
-					GeneratorURL: "",
-				},
-			},
-			GroupLabels:       map[string]string{},
-			CommonLabels:      map[string]string{},
-			CommonAnnotations: map[string]string{},
-			ExternalURL:       "",
-		}
-	}
-
-	// postAlert sends an alert to the OCM Agent similar to post-alert.sh
-	postAlert := func(ctx context.Context, alert AlertPayload) error {
-		alertJSON, err := json.Marshal(alert)
-		if err != nil {
-			return fmt.Errorf("failed to marshal alert: %v", err)
-		}
-
-		resp, err := httpClient.Post(
-			fmt.Sprintf("%s/alertmanager-receiver", ocmAgentURL),
-			"application/json",
-			bytes.NewBuffer(alertJSON),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to post alert: %v", err)
-		}
-		defer resp.Body.Close()
-
-		var alertResponse AlertResponse
-		if err := json.NewDecoder(resp.Body).Decode(&alertResponse); err != nil {
-			return fmt.Errorf("failed to decode response: %v", err)
-		}
-
-		if alertResponse.Status != "ok" {
-			return fmt.Errorf("alert posting failed with status: %s", alertResponse.Status)
-		}
-
-		return nil
-	}
-
-	// getServiceLogCount gets the count of service logs for a cluster
-	getServiceLogCount := func(ctx context.Context, clusterUUID string) (int, error) {
-		serviceLogsClient := ocmConnection.ServiceLogs().V1()
-
-		response, err := serviceLogsClient.Clusters().ClusterLogs().List().
-			Parameter("cluster_uuid", clusterUUID).
-			Send()
-		if err != nil {
-			return 0, fmt.Errorf("failed to get service logs: %v", err)
-		}
-
-		return response.Total(), nil
-	}
-
-	// checkServiceLogCount verifies the service log count matches expectations
-	checkServiceLogCount := func(ctx context.Context, clusterUUID string, preCount, expectedNew int) {
-		expectedTotal := preCount + expectedNew
-		actualCount, err := getServiceLogCount(ctx, clusterUUID)
-		Expect(err).Should(BeNil(), "failed to get service log count")
-		Expect(actualCount).Should(Equal(expectedTotal),
-			fmt.Sprintf("Expected SL count: %d, Got SL count: %d", expectedTotal, actualCount))
-	}
-
 	ginkgo.BeforeAll(func(ctx context.Context) {
-		// setup the k8s client
+		// Setup the k8s client
+		ginkgo.By("Setup: Setting up clients and prerequisites for tests")
 		cfg, err := config.GetConfig()
 		Expect(err).Should(BeNil(), "failed to get kubeconfig")
 		client, err = resources.New(cfg)
 		Expect(err).Should(BeNil(), "resources.New error")
-
 		k8sClient, err = k8s.NewClient()
 		Expect(err).Should(BeNil(), "Failed to create controller runtime client")
+
+		// Add required types to scheme
+		k8sClient.Scheme().AddKnownTypes(oav1alpha1.GroupVersion, &oav1alpha1.OcmAgent{})
+		k8sClient.Scheme().AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
+		k8sClient.Scheme().AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Service{})
+
+		err = oav1alpha1.AddToScheme(k8sClient.Scheme())
+		if err != nil {
+			ginkgo.Fail("Failed to add ocmagent to scheme")
+		}
+
+		err = appsv1.AddToScheme(k8sClient.Scheme())
+		if err != nil {
+			ginkgo.Fail("Failed to add deployment to scheme")
+		}
+
+		err = corev1.AddToScheme(k8sClient.Scheme())
+		if err != nil {
+			ginkgo.Fail("Failed to add service to scheme")
+		}
 
 		// Create a mock error server that always returns 503
 		errorServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -333,23 +111,17 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 			w.Write([]byte(`{"message": "Service temporarily unavailable", "code": 503}`))
 		}))
 
-		// If OCM_AGENT_URL is set, test is running locally, take the local ocm-agent url
-		if localOcmAgentUrl := os.Getenv("OCM_AGENT_URL"); localOcmAgentUrl != "" {
-			ocmAgentURL = localOcmAgentUrl
-		}
-
-		//Create ocm connection
-		ginkgo.By("getting OCM configuration from ocm-agent configmap")
+		ginkgo.By("Setup: Getting OCM configuration from ocm-agent configmap")
 		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ocmAgentConfigMap, Namespace: namespace}}
 		err = client.Get(ctx, configMap.Name, configMap.Namespace, configMap)
 		// Verify required configuration fields
 		Expect(err).Should(BeNil(), "ocm-agent configmap not found")
 
-		ginkgo.By("getting real external cluster ID from configmap")
+		ginkgo.By("Setup: Getting real external cluster ID from configmap")
 		if err == nil {
 			if configMap.Data[clusterIDKey] != "" {
 				externalClusterID = configMap.Data[clusterIDKey]
-				ginkgo.By(fmt.Sprintf("externalClusterId %s", externalClusterID))
+				ginkgo.By(fmt.Sprintf("Setup: External cluster ID: %s", externalClusterID))
 			}
 		}
 
@@ -370,26 +142,19 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 			}
 		}
 		Expect(externalClusterID).ShouldNot(BeEmpty(), "external cluster ID should not be empty")
-
-		ginkgo.By("Getting if fleet mode is enabled with ocm-agent configmap")
-		fleetConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: ocmAgentFleetConfigMap, Namespace: namespace}}
-		err = client.Get(ctx, fleetConfigMap.Name, fleetConfigMap.Namespace, fleetConfigMap)
-		if err == nil {
-			// If we could get ocm-agent-fleet-cm, then ocm-agent is in fleet mode
-			isFleetMode = true
+		Expect(configMap.Data).Should(HaveKey(ocmBaseURLKey), "ocmBaseURL not configured")
+		Expect(configMap.Data).Should(HaveKey(servicesKey), "services not configured")
+		ocmBaseURL = configMap.Data[ocmBaseURLKey]
+		Expect(ocmBaseURL).ShouldNot(BeEmpty(), "ocmBaseURL is empty")
+		Expect(configMap.Data[servicesKey]).ShouldNot(BeEmpty(), "services configuration is empty")
+		// override when OCM_URL is set
+		if os.Getenv("OCM_URL") != "" {
+			ocmBaseURL = os.Getenv("OCM_URL")
 		}
-		if isFleetMode {
-			Expect(fleetConfigMap.Data).Should(HaveKey(ocmBaseURLKey), "ocmBaseURL not configured")
-			Expect(fleetConfigMap.Data).Should(HaveKey(servicesKey), "services not configured")
-			ocmBaseURL = fleetConfigMap.Data[ocmBaseURLKey]
-			Expect(ocmBaseURL).ShouldNot(BeEmpty(), "ocmBaseURL is empty")
-			Expect(fleetConfigMap.Data[servicesKey]).ShouldNot(BeEmpty(), "services configuration is empty")
-		} else {
-			Expect(configMap.Data).Should(HaveKey(ocmBaseURLKey), "ocmBaseURL not configured")
-			Expect(configMap.Data).Should(HaveKey(servicesKey), "services not configured")
-			ocmBaseURL = configMap.Data[ocmBaseURLKey]
-			Expect(ocmBaseURL).ShouldNot(BeEmpty(), "ocmBaseURL is empty")
-			Expect(configMap.Data[servicesKey]).ShouldNot(BeEmpty(), "services configuration is empty")
+		fmt.Sprintf("ocmBaseURL is %v", ocmBaseURL)
+		// Override the ocm-agent URL if the OCM_AGENT_URL environment variable is set
+		if os.Getenv("OCM_AGENT_URL") != "" {
+			ocmAgentURL = os.Getenv("OCM_AGENT_URL")
 		}
 
 		// Get access token from env or secret
@@ -400,7 +165,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}
 
 		// Create OCM connection and get internal cluster ID
-		ginkgo.By("creating OCM connection and getting internal cluster ID")
+		ginkgo.By("Setup: Creating OCM connection and getting internal cluster ID")
 		logger, err := sdk.NewGoLoggerBuilder().Debug(false).Build()
 		Expect(err).To(BeNil())
 
@@ -431,45 +196,25 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}
 		Expect(internalClusterID).ShouldNot(BeEmpty(), "internal cluster ID should not be empty")
 
-		ginkgo.By("creating networkpolicy to allow traffic from all namespace")
-		err = createNetworkPolicy(ctx)
+		ginkgo.By("Setup: Creating network policy to allow traffic from all namespaces")
+		err = testconst.CreateNetworkPolicy(ctx, client, networkPolicyName, namespace)
 		Expect(err).To(BeNil(), fmt.Sprintf("Failed to create networkpolicy %v", err))
-
 	})
-
-	ginkgo.AfterAll(func(ctx context.Context) {
-		// Clean up the error server
-		if errorServer != nil {
-			errorServer.Close()
-		}
-		networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyName, Namespace: namespace}}
-		err := client.Get(ctx, networkPolicy.Name, networkPolicy.Namespace, networkPolicy)
-		if err == nil {
-			// If networkpolicy exist, delete it
-			client.Delete(ctx, networkPolicy)
-		}
-
-	})
-
-	ginkgo.It("Testing - basic deployment", func(ctx context.Context) {
-
-		// Testing
-		ginkgo.By("checking the namespace exists")
+	ginkgo.It("OcmAgentCommon - Testing basic deployment", Label("OcmAgentCommon"), func(ctx context.Context) {
+		ginkgo.By("Step 1: Verifying that the namespace exists")
 		err := client.Get(ctx, namespace, "", &corev1.Namespace{})
 		Expect(err).Should(BeNil(), "namespace %s not found", namespace)
 
-		ginkgo.By("checking the deployment exists")
+		ginkgo.By("Step 2: Verifying that the deployment exists")
 		for _, deploymentName := range deployments {
 			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: namespace}}
 			err = wait.For(conditions.New(client).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, corev1.ConditionTrue))
 			Expect(err).Should(BeNil(), "deployment %s not available", deploymentName)
 		}
-
 	})
 
-	ginkgo.It("Testing - common ocm-agent tests", func(ctx context.Context) {
-		// Get OCM Agent pod for testing
-		ginkgo.By("getting ocm-agent pod for testing")
+	ginkgo.It("OcmAgentCommon - Testing common ocm-agent tests", Label("OcmAgentCommon"), func(ctx context.Context) {
+		ginkgo.By("Step 1: Listing ocm-agent pods for testing")
 		podList := &corev1.PodList{}
 		err := client.List(ctx, podList, func(o *metav1.ListOptions) {
 			o.LabelSelector = ocmAgentLabelSelector
@@ -486,7 +231,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		Expect(ocmAgentPodName).ShouldNot(BeEmpty(), "no running ocm-agent pod found")
 
 		// Wait for the ocm-agent service to be ready
-		ginkgo.By("waiting for the ocm-agent service to be ready")
+		ginkgo.By("Step 2: Verifying ocm-agent service is ready")
 		Eventually(func() error {
 			resp, err := httpClient.Get(fmt.Sprintf("%s/livez", ocmAgentURL))
 			if err != nil {
@@ -499,27 +244,8 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 			return nil
 		}, "2m", "5s").Should(Succeed(), "ocm-agent service should be available")
 
-		// TEST - Ensure that ocm-agent starts successfully
-		ginkgo.By("verifying ocm-agent starts successfully")
-		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: ocmAgentPodName, Namespace: namespace}}
-		err = client.Get(ctx, pod.Name, pod.Namespace, pod)
-		Expect(err).Should(BeNil(), "failed to get ocm-agent pod")
-		Expect(pod.Status.Phase).Should(Equal(corev1.PodRunning), "ocm-agent pod is not running")
-
-		// Check container status
-		Expect(len(pod.Status.ContainerStatuses)).Should(BeNumerically(">", 0), "no container statuses found")
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			Expect(containerStatus.Ready).Should(BeTrue(), "container %s is not ready", containerStatus.Name)
-			Expect(containerStatus.RestartCount).Should(BeNumerically("<=", 2), "container %s has too many restarts", containerStatus.Name)
-		}
-
-		// TEST - Ensure that ocm-agent is able to configure and build an ocm connection successfully
-		ginkgo.By("verifying ocm connection configuration")
-		// Already verified above by successfully creating OCM connection and getting internal cluster ID
-
 		// TEST - Ensure that ocm-agent sends a successful health check request to ocm api
-		ginkgo.By("testing health check endpoints")
-
+		ginkgo.By("Step 3: Testing health check endpoints")
 		// Test livez endpoint
 		resp, err := httpClient.Get(fmt.Sprintf("%s/livez", ocmAgentURL))
 		if err == nil {
@@ -535,49 +261,15 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}
 
 		// TEST - Verify that the ocm-agent handles 4xx(400 Not Found) response gracefully
-		ginkgo.By("testing 4xx error handling")
-
-		// Test with invalid endpoint
+		ginkgo.By("Step 4: Verifying invalid endpoint returns 4xx error")
 		resp, err = httpClient.Get(fmt.Sprintf("%s/invalid-endpoint", ocmAgentURL))
 		if err == nil {
 			Expect(resp.StatusCode).Should(Equal(http.StatusNotFound), "should return 404 for invalid endpoint")
 			resp.Body.Close()
 		}
 
-		// Check logs for graceful error handling
-		ginkgo.By("checking logs for error handling patterns")
-		// This would require log analysis - implementation depends on log aggregation setup
-
-		// TEST - Verify the timeout handling when ocm api responds slowly
-		ginkgo.By("testing timeout handling")
-
-		// Create client with very short timeout
-		shortTimeoutClient := &http.Client{Timeout: 1 * time.Millisecond}
-
-		// Test timeout behavior (this should timeout)
-		_, err = shortTimeoutClient.Get(fmt.Sprintf("%s/readyz", ocmAgentURL))
-		// We expect this to timeout or fail gracefully
-
-		// TEST - Get list of all the upgrade policies belonging to a cluster from ocm api
-		ginkgo.By("testing upgrade policies API endpoint with real internal cluster ID")
-
-		// Test if upgrade policies endpoint exists and responds
-		resp, err = httpClient.Get(fmt.Sprintf("%s/api/clusters_mgmt/v1/clusters/%s/upgrade_policies", ocmAgentURL, internalClusterID))
-		if err == nil {
-			// Should handle the request even if cluster doesn't exist
-			Expect(resp.StatusCode).Should(BeElementOf([]int{http.StatusOK, http.StatusNotFound, http.StatusUnauthorized}),
-				"unexpected status code for upgrade policies endpoint")
-			resp.Body.Close()
-		}
-
-		// TEST - Verify that ocm-agent sends a successful request to ocm api to get all upgrade policies
-		ginkgo.By("verifying upgrade policies request handling")
-
-		// Check if the agent properly proxies requests
-		// This test verifies the proxy functionality without requiring actual cluster data
-
 		// TEST - Fetch Limited support reasons for cluster
-		ginkgo.By("testing limited support reasons full workflow")
+		ginkgo.By("Step 5: Testing limited support reasons full workflow")
 
 		ocmClient := ocm.NewOcmClient(ocmConnection)
 		limitedSupportSummary := "E2E Test Limited Support"
@@ -586,7 +278,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Step 1: Create a limited support reason
-		ginkgo.By("creating limited support reason via OCM client")
+		ginkgo.By("Step 5a: Creating limited support reason via OCM client")
 		err = ocmClient.SendLimitedSupport(externalClusterID, lsReason)
 		if err != nil {
 			ginkgo.GinkgoWriter.Printf("Skipping test: Failed to create limited support reason. Error: %v\n", err)
@@ -594,7 +286,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}
 
 		// Since SendLimitedSupport doesn't return the ID, we have to find it.
-		ginkgo.By("finding the created limited support reason to get its ID")
+		ginkgo.By("Step 5b: Finding the created limited support reason to get its ID")
 		var limitedSupportReasonID string
 		reasons, err := ocmClient.GetLimitedSupportReasons(externalClusterID)
 		if err != nil {
@@ -611,7 +303,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		// Ensure cleanup happens even if tests fail
 		defer func() {
 			if limitedSupportReasonID != "" {
-				ginkgo.By("cleaning up - deleting limited support reason")
+				ginkgo.By("Cleanup: Deleting limited support reason")
 				err := ocmClient.RemoveLimitedSupport(externalClusterID, limitedSupportReasonID)
 				if err != nil {
 					fmt.Printf("Failed to cleanup limited support reason %s: %v\n", limitedSupportReasonID, err)
@@ -620,7 +312,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}()
 
 		// Step 2: Test retrieval of limited support reasons through ocm-agent
-		ginkgo.By("testing limited support reasons retrieval through ocm-agent")
+		ginkgo.By("Step 5c: Testing limited support reasons retrieval through ocm-agent")
 
 		// Test limited support endpoint - should now return the created reason
 		resp, err = httpClient.Get(fmt.Sprintf("%s/api/clusters_mgmt/v1/clusters/%s/limited_support_reasons", ocmAgentURL, internalClusterID))
@@ -649,7 +341,7 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 		}
 
 		// Step 3: Test retrieval of specific limited support reason
-		ginkgo.By("testing specific limited support reason retrieval")
+		ginkgo.By("Step 5d: Testing specific limited support reason retrieval")
 
 		resp, err = httpClient.Get(fmt.Sprintf("%s/api/clusters_mgmt/v1/clusters/%s/limited_support_reasons/%s", ocmAgentURL, internalClusterID, limitedSupportReasonID))
 		if err != nil {
@@ -660,124 +352,386 @@ var _ = ginkgo.Describe("ocm-agent", ginkgo.Ordered, func() {
 				"unexpected status code for specific limited support reason")
 			defer resp.Body.Close()
 		}
-
-		// Final verification - ensure agent is still healthy after all tests
-		ginkgo.By("final health verification after all tests")
-		resp, err = httpClient.Get(fmt.Sprintf("%s/readyz", ocmAgentURL))
-		if err == nil {
-			Expect(resp.StatusCode).Should(Equal(http.StatusOK), "ocm-agent unhealthy after tests")
-			resp.Body.Close()
-		}
-
-		// Verify pod is still running and stable
-		finalPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: ocmAgentPodName, Namespace: namespace}}
-		err = client.Get(ctx, finalPod.Name, finalPod.Namespace, finalPod)
-		Expect(err).Should(BeNil(), "failed to get ocm-agent pod after tests")
-		Expect(finalPod.Status.Phase).Should(Equal(corev1.PodRunning), "ocm-agent pod not running after tests")
 	})
+	ginkgo.It("OcmAgentClassic - Testing alert processing for classic mode", Label("OcmAgentClassic"), func(ctx context.Context) {
 
-	ginkgo.It("Testing - Alert processing for classic mode", func(ctx context.Context) {
-		if isFleetMode {
-			ginkgo.GinkgoWriter.Printf("Skipping test: Skip the tests for classic mode.")
-			ginkgo.Skip(fmt.Sprintf("Ocm-agent is in fleet mode, skip the tests for classic mode."))
-		}
-
-		ginkgo.By("Delete and create default managed notification so that ")
+		ginkgo.By("Step 1: Creating and managing default ManagedNotification")
 		managedNotification := &oav1alpha1.ManagedNotification{}
-		err := k8sClient.Get(ctx, crclient.ObjectKey{Name: ocmAgentManagedNotification, Namespace: namespace}, managedNotification)
+		err := k8sClient.Get(ctx, crClient.ObjectKey{Name: ocmAgentManagedNotification, Namespace: namespace}, managedNotification)
 		if err != nil {
 			// If notification doesn't exist, create default notification
-			err = createDefaultNotification(ctx)
+			err = testconst.CreateDefaultNotification(ctx, k8sClient, namespace, ocmAgentManagedNotification, testNotificationName)
 			Expect(err).Should(BeNil(), "failed to create default ManagedNotification")
 		} else {
 			// If notification exists, delete it then create default for testing
 			err = k8sClient.Delete(ctx, managedNotification)
 			Expect(err).Should(BeNil(), "failed to delete existing ManagedNotification")
-			err = createDefaultNotification(ctx)
+			err = testconst.CreateDefaultNotification(ctx, k8sClient, namespace, ocmAgentManagedNotification, testNotificationName)
 			Expect(err).Should(BeNil(), "failed to create default ManagedNotification")
 		}
 
 		// TEST - Verify http request actions
-		ginkgo.By("TEST - http GET should not be supported")
+		ginkgo.By("Step 2: Verifying HTTP GET is not supported on alertmanager-receiver")
 		resp, err := httpClient.Get(fmt.Sprintf("%s/alertmanager-receiver", ocmAgentURL))
 		Expect(resp.StatusCode).ShouldNot(Equal(http.StatusOK))
 
 		// TEST - Get servicelog count before sending alert
-		ginkgo.By("TEST - sending service log for a firing alert")
-		preServiceLogCount, err := getServiceLogCount(ctx, externalClusterID)
+		ginkgo.By("Step 3: Sending service log for a firing alert")
+		preServiceLogCount, err := testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
 		Expect(err).Should(BeNil(), "failed to get initial service log count")
 
-		firingAlert := createSingleAlert("firing", "LoggingVolumeFillingUpNotificationSRE", testNotificationName)
+		firingAlert := testconst.CreateSingleAlert("firing", alertName, testNotificationName)
 		// TEST - Verify alert has notification template associated
-		ginkgo.By("TEST - Alert should have notification template associated")
+		ginkgo.By("Step 4: Verifying alert has notification template associated")
 		Expect(firingAlert.Alerts[0].Labels["managed_notification_template"]).ShouldNot(BeNil(), "No managed notification template for alert")
 		Expect(firingAlert.Alerts[0].Labels["managed_notification_template"]).Should(Equal(testNotificationName))
 
 		// Test - Post alert
-		ginkgo.By("TEST - Post single alert, servicelog count should be increased by 1")
-		err = postAlert(ctx, firingAlert)
+		ginkgo.By("Step 5: Posting single alert, service log count should increase by 1")
+		err = testconst.PostAlert(ctx, firingAlert, httpClient, ocmAgentURL)
 		Expect(err).Should(BeNil(), "failed to post firing alert")
-		time.Sleep(3 * time.Second)
-		checkServiceLogCount(ctx, externalClusterID, preServiceLogCount, 1)
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preServiceLogCount, 1, ocmConnection)
 
 		// TEST - Do not send Service Log again for the same firing alert
-		ginkgo.By("TEST - Not sending service log again for same firing alert within resend period")
-		preServiceLogCount, err = getServiceLogCount(ctx, externalClusterID)
+		ginkgo.By("Step 6: Verifying no duplicate service log for same firing alert within resend period")
+		preServiceLogCount, err = testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
 		Expect(err).Should(BeNil(), "failed to get service log count before duplicate test")
 
-		duplicateAlert := createSingleAlert("firing", "LoggingVolumeFillingUpNotificationSRE", testNotificationName)
-		err = postAlert(ctx, duplicateAlert)
+		duplicateAlert := testconst.CreateSingleAlert("firing", alertName, testNotificationName)
+		err = testconst.PostAlert(ctx, duplicateAlert, httpClient, ocmAgentURL)
 		Expect(err).Should(BeNil(), "failed to post duplicate firing alert")
 
 		// Wait for processing
-		time.Sleep(3 * time.Second)
-		checkServiceLogCount(ctx, externalClusterID, preServiceLogCount, 0)
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preServiceLogCount, 0, ocmConnection)
 
 		// TEST - Send Service Log for resolved alert
-		ginkgo.By("TEST - Sending service log for resolved alert")
-		preServiceLogCount, err = getServiceLogCount(ctx, externalClusterID)
+		ginkgo.By("Step 7: Sending service log for resolved alert")
+		preServiceLogCount, err = testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
 		Expect(err).Should(BeNil(), "failed to get service log count before resolved test")
 
-		resolvedAlert := createSingleAlert("resolved", "LoggingVolumeFillingUpNotificationSRE", testNotificationName)
-		err = postAlert(ctx, resolvedAlert)
+		resolvedAlert := testconst.CreateSingleAlert("resolved", alertName, testNotificationName)
+		err = testconst.PostAlert(ctx, resolvedAlert, httpClient, ocmAgentURL)
 		Expect(err).Should(BeNil(), "failed to post resolved alert")
 
 		// Wait for processing
-		time.Sleep(3 * time.Second)
-		checkServiceLogCount(ctx, externalClusterID, preServiceLogCount, 1)
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preServiceLogCount, 1, ocmConnection)
 
 		// TEST - Firing 2 alerts, servicelog count should be increased by 2
-		ginkgo.By("TEST - Firing 2 alerts, servicelog count should be increased by 2")
-		preServiceLogCount, err = getServiceLogCount(ctx, externalClusterID)
+		ginkgo.By("Step 8: Firing 2 alerts, service log count should increase by 2")
+		preServiceLogCount, err = testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
 		Expect(err).Should(BeNil(), "failed to get service log count before resolved test")
 
-		biAlerts := createBiAlert("firing", "TestAlert", "ParallelAlert")
-		err = postAlert(ctx, biAlerts)
+		biAlerts := testconst.CreateBiAlert("firing", "TestAlert", "ParallelAlert")
+		err = testconst.PostAlert(ctx, biAlerts, httpClient, ocmAgentURL)
 		Expect(err).Should(BeNil(), "failed to post resolved alert")
 
 		// Wait for processing
-		time.Sleep(3 * time.Second)
-		checkServiceLogCount(ctx, externalClusterID, preServiceLogCount, 2)
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preServiceLogCount, 2, ocmConnection)
 
 		// TEST - Resolve 2 alerts, servicelog count should be increased by 2
-		ginkgo.By("TEST - Resolve 2 alerts, servicelog count should be increased by 2")
-		preServiceLogCount, err = getServiceLogCount(ctx, externalClusterID)
+		ginkgo.By("Step 9: Resolving 2 alerts, service log count should increase by 2")
+		preServiceLogCount, err = testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
 		Expect(err).Should(BeNil(), "failed to get service log count before resolved test")
 
-		resolvedBiAlerts := createBiAlert("resolved", "TestAlert", "ParallelAlert")
-		err = postAlert(ctx, resolvedBiAlerts)
+		resolvedBiAlerts := testconst.CreateBiAlert("resolved", "TestAlert", "ParallelAlert")
+		err = testconst.PostAlert(ctx, resolvedBiAlerts, httpClient, ocmAgentURL)
 		Expect(err).Should(BeNil(), "failed to post resolved alert")
 
 		// Wait for processing
-		time.Sleep(3 * time.Second)
-		checkServiceLogCount(ctx, externalClusterID, preServiceLogCount, 2)
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preServiceLogCount, 2, ocmConnection)
 
-		ginkgo.By("verifying ocm-agent is still healthy after alert tests")
+		ginkgo.By("Step 10: Verifying ocm-agent is still healthy after alert tests")
 		resp, err = httpClient.Get(fmt.Sprintf("%s/readyz", ocmAgentURL))
 		if err == nil {
 			Expect(resp.StatusCode).Should(Equal(http.StatusOK), "ocm agent unhealthy after alert tests")
 			resp.Body.Close()
 		}
 	})
+	ginkgo.It("OcmAgentHCP - Testing ocm-agent tests in fleet mode", Label("OcmAgentHCP"), func(ctx context.Context) {
 
+		// set ocm agent url to fleet url when overriding OCM_AGENT_URL environment variable is not set
+		if os.Getenv("OCM_AGENT_URL") == "" {
+			ocmAgentURL = ocmAgentFleetURL
+		}
+
+		// Get OcmAgent "ocm-agent" resource
+		oa := &oav1alpha1.OcmAgent{}
+		err := k8sClient.Get(ctx, crClient.ObjectKey{Name: "ocm-agent", Namespace: namespace}, oa)
+		if err == nil {
+			Expect(err).Should(BeNil(), "failed to get ocm-agent OcmAgent resource")
+		}
+
+		// Get Deployment "ocm-agent" resource
+		oadeploy := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: deploymentName, Namespace: namespace}, oadeploy)
+		if err != nil {
+			Expect(err).Should(BeNil(), "failed to get ocm-agent deployment")
+		}
+		deployLabels := map[string]string{
+			"app": deploymentName + "-fleet",
+		}
+
+		// Setup fleet-mode deployment
+		// NOTE: For now we create deployment separately since the "--test-mode" flag isn't enabled via OcmAgent API
+		oadeployfleet := &appsv1.Deployment{}
+
+		// Get Deployment "ocm-agent-fleet" resource and create it if it doesn't exist
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: deploymentName + "-fleet", Namespace: namespace}, oadeployfleet)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("Creating fleet mode deployment since it doesn't exist")
+			oadeployfleet.Spec = *oadeploy.Spec.DeepCopy()
+			oadeployfleet.Name = deploymentName + "-fleet"
+			oadeployfleet.Namespace = namespace
+			oadeployfleet.Labels = deployLabels
+			oadeployfleet.Spec.Selector.MatchLabels = deployLabels
+			oadeployfleet.Spec.Template.ObjectMeta.Labels = deployLabels
+			// TODO: Remove the image override after testing
+			oadeployfleet.Spec.Template.Spec.Containers[0].Image = "quay.io/travi/ocm-agent@sha256:789386cdd992788f4656dc8c030373bea0347d1d313551123b2430875abed27d"
+			oadeployfleet.Spec.Template.Spec.Containers[0].Command = append(oadeployfleet.Spec.Template.Spec.Containers[0].Command, "--fleet-mode")
+			oadeployfleet.Spec.Template.Spec.Containers[0].Command = append(oadeployfleet.Spec.Template.Spec.Containers[0].Command, "--test-mode")
+
+			// For a failed test run, validate if the fleet mode deployment is already created or not
+			ginkgo.By("Setup: Creating OCM Agent Fleet mode deployment")
+			err = k8sClient.Create(ctx, oadeployfleet)
+			if err != nil {
+				Expect(err).Should(BeNil(), "failed to create ocm-agent-fleet deployment resource")
+			}
+
+			deployments = []string{deploymentName + "-fleet"}
+			for _, deploymentName := range deployments {
+				deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: namespace}}
+				err = wait.For(conditions.New(client).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, corev1.ConditionTrue))
+				Expect(err).Should(BeNil(), "deployment %s not available", deploymentName)
+			}
+		}
+
+		// Get Service "ocm-agent-fleet" resource and create it if it doesn't exist
+		oasvcfleet := &corev1.Service{}
+		oasvc := &corev1.Service{}
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: deploymentName, Namespace: namespace}, oasvc)
+		if err != nil {
+			Expect(err).Should(BeNil(), "failed to get ocm-agent service resource")
+		}
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: deploymentName + "-fleet", Namespace: namespace}, oasvcfleet)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("Creating fleet mode service since it doesn't exist")
+			oasvcfleet.Spec = *oasvc.Spec.DeepCopy()
+			oasvcfleet.Name = oasvc.Name + "-fleet"
+			oasvcfleet.Namespace = oasvc.Namespace
+			oasvcfleet.Spec.Ports[0].Name = oasvc.Name + "-fleet"
+			oasvcfleet.Spec.Selector = deployLabels
+			oasvcfleet.Spec.ClusterIP = ""
+			oasvcfleet.Spec.ClusterIPs = []string{}
+			ginkgo.By("Setup: Creating OCM Agent Fleet mode service")
+			err = k8sClient.Create(ctx, oasvcfleet)
+			if err != nil {
+				Expect(err).Should(BeNil(), "failed to create ocm-agent-fleet service resource")
+			}
+		}
+
+		var (
+			// generate a random alphanumeric string for the mcClusterID in the format of 1111-2222-3333-44444
+			mcClusterID1 = "random-mc-id-1" //uuid.New().String()[:18]
+			mcClusterID2 = "random-mc-id-2" //uuid.New().String()[:18]
+			mcClusterID3 = "random-mc-id-3" //uuid.New().String()[:18]
+		)
+		// replicate the tests here http://github.com/openshift/ocm-agent/blob/master/test/test-fleet-alerts.sh
+		// Create a new ManagedFleetNotification object
+		var mFleetNotificationAuditWebhookErrorTemplate = &oav1alpha1.ManagedFleetNotification{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "ocmagent.managed.openshift.io/v1alpha1",
+				Kind:       "ManagedFleetNotification",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "audit-webhook-error-putting-minimized-cloudwatch-log",
+				Namespace: "openshift-ocm-agent-operator",
+			},
+			Spec: oav1alpha1.ManagedFleetNotificationSpec{
+				FleetNotification: oav1alpha1.FleetNotification{
+					Name:                "audit-webhook-error-putting-minimized-cloudwatch-log",
+					NotificationMessage: "An audit-event send to your CloudWatch failed delivery, due to the event being too large. The reduced event failed delivery as well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219",
+					ResendWait:          0,
+					Severity:            "Info",
+					Summary:             "Audit-events could not be delivered to your CloudWatch",
+				},
+			},
+		}
+
+		var mFleetNotificationOidcDeletedTemplate = &oav1alpha1.ManagedFleetNotification{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "ocmagent.managed.openshift.io/v1alpha1",
+				Kind:       "ManagedFleetNotification",
+			},
+
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oidc-deleted-notification",
+				Namespace: "openshift-ocm-agent-operator",
+			},
+			Spec: oav1alpha1.ManagedFleetNotificationSpec{
+				FleetNotification: oav1alpha1.FleetNotification{
+					Name:                "oidc-deleted-notification",
+					NotificationMessage: "Your cluster is degraded due to the deletion of the associated OpenIDConnectProvider. To restore full support, please recreate the OpenID Connect provider by executing the command: rosa create oidc-provider --mode manual --cluster $CLUSTER_ID",
+					ResendWait:          0,
+					Severity:            "Info",
+					Summary:             "Cluster is in Limited Support due to unsupported cloud provider configuration",
+					LimitedSupport:      true,
+				},
+			},
+		}
+
+		// TEST - Verify and recreate the default ManagedNotification template
+		ginkgo.By("Step 1: Creating test ManagedFleetNotification templates")
+
+		// Get the existing ManagedFleetNotification object
+		mFleetNotificationAuditWebhookError := &oav1alpha1.ManagedFleetNotification{}
+		// Check if the ManagedFleetNotification object audit-webhook-error-putting-minimized-cloudwatch-log exists
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: mFleetNotificationAuditWebhookErrorTemplate.Name, Namespace: namespace}, mFleetNotificationAuditWebhookError)
+		if err == nil && mFleetNotificationAuditWebhookError.Name != "" {
+			err = k8sClient.Delete(ctx, mFleetNotificationAuditWebhookError)
+			Expect(err).Should(BeNil(), "failed to delete FleetManagedNotification")
+		}
+		// Create a new ManagedFleetNotification object
+		err = k8sClient.Create(ctx, mFleetNotificationAuditWebhookErrorTemplate)
+		Expect(err).Should(BeNil(), "failed to create FleetManagedNotification")
+		// Check if the ManagedFleetNotification object oidc-deleted-notification exists
+		mFleetNotificationOidcDeleted := &oav1alpha1.ManagedFleetNotification{}
+		err = k8sClient.Get(ctx, crClient.ObjectKey{Name: mFleetNotificationOidcDeletedTemplate.Name, Namespace: namespace}, mFleetNotificationOidcDeleted)
+		if err == nil && mFleetNotificationOidcDeleted.Name != "" {
+			err = k8sClient.Delete(ctx, mFleetNotificationOidcDeleted)
+			Expect(err).Should(BeNil(), "failed to delete FleetManagedNotification")
+		}
+		// Create a new ManagedFleetNotification object
+		err = k8sClient.Create(ctx, mFleetNotificationOidcDeletedTemplate)
+		Expect(err).Should(BeNil(), "failed to create FleetManagedNotification")
+
+		// Delete all managed-fleet-notification-record objects before the test
+		err = k8sClient.DeleteAllOf(ctx, &oav1alpha1.ManagedFleetNotificationRecord{}, crClient.InNamespace("openshift-ocm-agent-operator"))
+		Expect(err).Should(BeNil(), "failed to delete managedfleetnotificationrecord objects")
+
+		// Remove all the limited support records after the test
+		defer func() {
+			// delete all the limited support records
+			ocmClient := ocm.NewOcmClient(ocmConnection)
+			limitedSupportReasons, err := ocmClient.GetLimitedSupportReasons(externalClusterID)
+			Expect(err).Should(BeNil(), "failed to get limited support reasons")
+			for _, r := range limitedSupportReasons {
+				err := ocmClient.RemoveLimitedSupport(externalClusterID, r.ID())
+				if err != nil {
+					fmt.Printf("Failed to delete limited support record: %v\n", err)
+				}
+			}
+			// resolve firing alerts
+			alertPayloadAuditWebhook := testconst.CreateFleetAlert("resolved", alertName, mcClusterID1, mFleetNotificationAuditWebhookErrorTemplate.ObjectMeta.Name, externalClusterID)
+			err = testconst.PostAlert(ctx, alertPayloadAuditWebhook, httpClient, ocmAgentURL)
+			Expect(err).Should(BeNil(), "failed to post alert")
+			testconst.PostAlert(ctx, alertPayloadAuditWebhook, httpClient, ocmAgentURL)
+			alertPayloadOidcDeleted := testconst.CreateFleetAlert("resolved", alertName, mcClusterID2, mFleetNotificationOidcDeletedTemplate.ObjectMeta.Name, externalClusterID)
+			err = testconst.PostAlert(ctx, alertPayloadOidcDeleted, httpClient, ocmAgentURL)
+			Expect(err).Should(BeNil(), "failed to post alert")
+			alertPayloadAuditWebhook = testconst.CreateFleetAlert("resolved", alertName, mcClusterID3, mFleetNotificationAuditWebhookErrorTemplate.ObjectMeta.Name, externalClusterID)
+			err = testconst.PostAlert(ctx, alertPayloadAuditWebhook, httpClient, ocmAgentURL)
+			Expect(err).Should(BeNil(), "failed to post alert")
+		}()
+
+		ginkgo.By("Step 2: Sending service log for a firing alert")
+
+		preSLCount, err := testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
+		Expect(err).Should(BeNil(), "failed to get service log count")
+		// create an alert payload for the audit-webhook-error-putting-minimized-cloudwatch-log
+		alertPayloadAuditWebhook := testconst.CreateFleetAlert("firing", alertName, mcClusterID1, mFleetNotificationAuditWebhookErrorTemplate.ObjectMeta.Name, externalClusterID)
+		// send the alert payload for the audit-webhook-error-putting-minimized-cloudwatch-log to the ocm-agent
+		err = testconst.PostAlert(ctx, alertPayloadAuditWebhook, httpClient, ocmAgentURL)
+		Expect(err).Should(BeNil(), "failed to post alert")
+		// wait for shortSleepInterval
+		time.Sleep(shortSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preSLCount, 1, ocmConnection)
+		testconst.CheckMfnriCount(ctx, mcClusterID1, 1, 0, k8sClient)
+
+		ginkgo.By("Step 3: Sending Limited Support for a firing alert")
+		// check the limited support count before the test starts
+		preLimitedSupportCount, err := testconst.GetLimitedSupportCount(ctx, internalClusterID, ocmConnection)
+		Expect(err).Should(BeNil(), "failed to get limited support count")
+		expectedLimitedSupportCount := preLimitedSupportCount + 1
+		// create an alert payload for the oidc-deleted-notification
+		alertPayloadOidcDeleted := testconst.CreateFleetAlert("firing", alertName, mcClusterID2, mFleetNotificationOidcDeletedTemplate.ObjectMeta.Name, externalClusterID)
+		// send the alert payload for the oidc-deleted-notification to the ocm-agent
+		err = testconst.PostAlert(ctx, alertPayloadOidcDeleted, httpClient, ocmAgentURL)
+		Expect(err).Should(BeNil(), "failed to post alert")
+		// wait for shortSleepInterval
+		time.Sleep(shortSleepInterval)
+
+		testconst.CheckLimitedSupportCount(ctx, internalClusterID, expectedLimitedSupportCount, ocmConnection)
+		testconst.CheckMfnriCount(ctx, mcClusterID2, 1, 0, k8sClient)
+
+		ginkgo.By("Step 4: Resending Limited Support for a firing alert without resolve")
+
+		time.Sleep(shortSleepInterval)
+		testconst.CheckLimitedSupportCount(ctx, internalClusterID, expectedLimitedSupportCount, ocmConnection)
+		testconst.CheckMfnriCount(ctx, mcClusterID2, 1, 0, k8sClient)
+
+		ginkgo.By("Step 5: Removing Limited Support for resolved alert")
+
+		preLimitedSupportCount, err = testconst.GetLimitedSupportCount(ctx, internalClusterID, ocmConnection)
+		// create an alert payload for the oidc-deleted-notification
+		alertPayloadOidcDeleted = testconst.CreateFleetAlert("resolved", alertName, mcClusterID2, mFleetNotificationOidcDeletedTemplate.ObjectMeta.Name, externalClusterID)
+		// send the alert payload for the oidc-deleted-notification to the ocm-agent
+		err = testconst.PostAlert(ctx, alertPayloadOidcDeleted, httpClient, ocmAgentURL)
+		Expect(err).Should(BeNil(), "failed to post alert")
+		time.Sleep(shortSleepInterval)
+		expectedLimitedSupportCount = preLimitedSupportCount - 1
+		Expect(err).Should(BeNil(), "failed to get limited support count")
+		testconst.CheckLimitedSupportCount(ctx, internalClusterID, expectedLimitedSupportCount, ocmConnection)
+		testconst.CheckMfnriCount(ctx, mcClusterID2, 1, 1, k8sClient)
+
+		ginkgo.By("Step 6: Sending service log for a firing alert (multiple times)")
+
+		preSLCount, err = testconst.GetServiceLogCount(ctx, externalClusterID, ocmConnection)
+		Expect(err).Should(BeNil(), "failed to get service log count")
+
+		// create an alert payload for the oidc-deleted-notification
+		alertPayloadAuditWebhook = testconst.CreateFleetAlert("firing", alertName, mcClusterID3, mFleetNotificationAuditWebhookErrorTemplate.ObjectMeta.Name, externalClusterID)
+		// send the alert payload for the oidc-deleted-notification to the ocm-agent 10 times
+		for i := 0; i < 10; i++ {
+			err = testconst.PostAlert(ctx, alertPayloadAuditWebhook, httpClient, ocmAgentURL)
+			Expect(err).Should(BeNil(), "failed to post alert")
+		}
+		// wait for longSleepInterval
+		time.Sleep(longSleepInterval)
+		testconst.CheckServiceLogCount(ctx, externalClusterID, preSLCount, 10, ocmConnection)
+		testconst.CheckMfnriCount(ctx, mcClusterID3, 10, 0, k8sClient)
+	})
+
+	ginkgo.AfterAll(func(ctx context.Context) {
+		// Clean up the error server
+		if errorServer != nil {
+			errorServer.Close()
+		}
+		ginkgo.By("Cleanup: Removing network policy")
+		networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkPolicyName, Namespace: namespace}}
+		err := client.Get(ctx, networkPolicy.Name, networkPolicy.Namespace, networkPolicy)
+		if err == nil {
+			// If networkpolicy exist, delete it
+			client.Delete(ctx, networkPolicy)
+		}
+
+		ginkgo.By("Cleanup: Removing fleet-mode deployment")
+		oadeployfleet := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "ocm-agent-fleet", Namespace: namespace}}
+		err = client.Get(ctx, oadeployfleet.Name, namespace, oadeployfleet)
+		if err == nil {
+			client.Delete(ctx, oadeployfleet)
+		}
+
+		ginkgo.By("Cleanup: Removing fleet-mode service")
+		oadeploysvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "ocm-agent-fleet", Namespace: namespace}}
+		err = client.Get(ctx, oadeployfleet.Name, namespace, oadeploysvc)
+		if err == nil {
+			client.Delete(ctx, oadeploysvc)
+		}
+
+	})
 })


### PR DESCRIPTION
### What type of PR is this?
_(test)_

### What this PR does / why we need it?
This PR is mainly contributing over commits from PR https://github.com/openshift/ocm-agent/pull/158 to help add the e2e tests for ocm-agent in fleet mode. 

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ [SREP-912](https://issues.redhat.com/browse/SREP-912)

### Special notes for your reviewer:
- Additional flag `--test-mode` has been added for `ocm-agent` CLI just for use in `--fleet-mode` when we can alternatively use accesstoken as well for OCM API calls instead of OCM client id/secret. 
- Tests are split into `OcmAgentCommon`, `OcmAgentClassic` and `OcmAgentHCP` tests
- README is updated further with command references
- For time being, fleet-mode testing is done by creating a new ocm-agent deployment and service directly compared to creating a new `OcmAgent` resource in fleetmode since the `OcmAgent` API doesn't support `--test-mode` and requires updating the deployment handler in ocm-agent-operator too. Thus to keep it simpler for sake of E2E tests, this approach has been taken for now.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Ran `make generate` command locally to validate code changes
- [x] Included documentation changes with PR

