### PR TITLE
Enable Dependabot for Go modules with auto-merge support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,18 @@ updates:
     ignore:
       - dependency-name: "openshift/release"
         # don't automatically upgrade golang version here
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      ocm-dependencies:
+        patterns:
+          - "github.com/openshift-online/ocm-sdk-go"


### PR DESCRIPTION
Add gomod ecosystem to Dependabot configuration for weekly Go dependency updates. Groups k8s and OCM dependencies for cleaner PRs.


_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR

