### PR TITLE
Add dependabot automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,24 @@ updates:
     ignore:
       - dependency-name: "openshift/release"
         # don't automatically upgrade golang version here
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      openshift:
+        patterns:
+          - "github.com/openshift/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      aws-sdk:
-        patterns:
-          - "github.com/aws/aws-sdk-go-v2*"
       kubernetes:
         patterns:
           - "k8s.io/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,21 +10,3 @@ updates:
     ignore:
       - dependency-name: "openshift/release"
         # don't automatically upgrade golang version here
-  - package-ecosystem: "gomod"
-    directory: "/"
-    labels:
-      - "area/dependency"
-      - "ok-to-test"
-    schedule:
-      interval: "weekly"
-    groups:
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      openshift:
-        patterns:
-          - "github.com/openshift/*"
-      prometheus:
-        patterns:
-          - "github.com/prometheus/*"

--- a/.github/workflows/branch-protection-check.yml
+++ b/.github/workflows/branch-protection-check.yml
@@ -1,0 +1,139 @@
+name: Branch Protection Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-dependabot-config:
+    name: Verify Dependabot Configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check Dependabot Config
+        run: |
+          echo "Verifying Dependabot configuration..."
+
+          if [ -f ".github/dependabot.yml" ]; then
+            echo "Dependabot configuration found"
+            echo ""
+            echo "Configuration summary:"
+            grep -A 10 "package-ecosystem:" .github/dependabot.yml || true
+          else
+            echo "Dependabot configuration missing"
+            exit 1
+          fi
+
+  verify-workflows:
+    name: Verify Auto-Merge Workflows
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check Required Workflows and Branch Protection
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Verifying auto-merge workflows..."
+
+          required_workflows=(
+            ".github/workflows/dependabot-auto-merge.yml"
+          )
+
+          all_present=true
+
+          for workflow in "${required_workflows[@]}"; do
+            if [ -f "$workflow" ]; then
+              echo "$workflow found"
+            else
+              echo "$workflow missing"
+              all_present=false
+            fi
+          done
+
+          if [ "$all_present" = false ]; then
+            echo ""
+            echo "Some required workflows are missing. Auto-merge may not work properly."
+          else
+            echo ""
+            echo "All required workflows are present"
+          fi
+
+          echo ""
+          echo "Verifying branch protection settings for default branch..."
+
+          REPO="${{ github.repository }}"
+          BRANCH="master"
+
+          protection_response=$(curl -s -w "\n%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${REPO}/branches/${BRANCH}/protection")
+
+          http_code=$(echo "$protection_response" | tail -n1)
+          protection_json=$(echo "$protection_response" | sed '$d')
+
+          if [[ "$http_code" -eq 404 ]]; then
+            echo "Branch protection is NOT enabled for ${BRANCH}"
+            echo "Missing: Branch protection rules"
+            all_present=false
+          elif [[ "$http_code" -ne 200 ]]; then
+            echo "Warning: Could not fetch branch protection settings (HTTP $http_code)"
+            echo "This may be due to insufficient permissions. Skipping branch protection validation."
+            echo "Response: $protection_json"
+          else
+            echo "Branch protection is enabled for ${BRANCH}"
+            echo ""
+
+            echo "Checking required status checks..."
+            status_checks=$(echo "$protection_json" | jq -r '.required_status_checks // empty')
+
+            if [[ -z "$status_checks" || "$status_checks" == "null" ]]; then
+              echo "Missing: required_status_checks is not configured"
+              all_present=false
+            else
+              strict=$(echo "$status_checks" | jq -r '.strict // false')
+              contexts=$(echo "$status_checks" | jq -r '.contexts // []')
+              checks=$(echo "$status_checks" | jq -r '.checks // []')
+
+              echo "  - Require branches to be up to date: $strict"
+
+              context_count=$(echo "$contexts" | jq -r 'length')
+              checks_count=$(echo "$checks" | jq -r 'length')
+
+              if [[ "$context_count" -eq 0 && "$checks_count" -eq 0 ]]; then
+                echo "Missing: No required status checks configured"
+                all_present=false
+              else
+                echo "  - Required status checks configured: $((context_count + checks_count))"
+              fi
+            fi
+
+            echo ""
+            echo "Checking required pull request reviews..."
+            pr_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews // empty')
+
+            if [[ -z "$pr_reviews" || "$pr_reviews" == "null" ]]; then
+              echo "  - Required pull request reviews: not configured (optional for auto-merge)"
+            else
+              required_approvals=$(echo "$pr_reviews" | jq -r '.required_approving_review_count // 0')
+              echo "  - Required approving reviews: $required_approvals"
+            fi
+          fi
+
+          echo ""
+          if [ "$all_present" = false ]; then
+            echo "Branch protection validation failed. Please configure the missing settings."
+            exit 1
+          fi
+
+          echo "Branch protection validation passed"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,119 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  actions: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only run for Dependabot PRs
+    if: github.actor == 'dependabot[bot]' && github.repository == '--add-gomod'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Check PR Labels
+        id: check-labels
+        run: |
+          echo "has-required-labels=true" >> $GITHUB_OUTPUT
+          echo "✅ Dependabot PR detected - auto-merge enabled for safe updates"
+
+      - name: Enable Auto-Merge for Safe Updates
+        if: |
+          steps.check-labels.outputs.has-required-labels == 'true' && (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-digest'
+          )
+        run: |
+          echo "Enabling auto-merge for ${{ steps.metadata.outputs.update-type }} update"
+          echo "Dependency: ${{ steps.metadata.outputs.dependency-names }}"
+          echo "Previous version: ${{ steps.metadata.outputs.previous-version }}"
+          echo "New version: ${{ steps.metadata.outputs.new-version }}"
+
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GH_TOKEN
+
+          PR_NODE_ID=$(curl -s \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+            | jq -r '.node_id')
+
+          if [[ -z "$PR_NODE_ID" || "$PR_NODE_ID" == "null" ]]; then
+            echo "❌ Failed to fetch PR node ID"
+            exit 1
+          fi
+
+          echo "PR Node ID: $PR_NODE_ID"
+
+          # GraphQL returns HTTP 200 even when mutations fail; errors are in the JSON body.
+          response=$(curl -s -w "%{http_code}" -o /tmp/response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/graphql" \
+            -d "{\"query\":\"mutation { enablePullRequestAutoMerge(input: { pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH }) { pullRequest { autoMergeRequest { enabledAt } } } }\"}")
+
+          if [[ "$response" -eq 200 ]] && \
+             jq -e '.errors == null and (.data.enablePullRequestAutoMerge.pullRequest.autoMergeRequest.enabledAt != null)' /tmp/response.json >/dev/null; then
+            echo "✅ Auto-merge enabled successfully via GraphQL"
+            cat /tmp/response.json
+          else
+            echo "❌ Failed to enable auto-merge. HTTP status: $response"
+            echo "Response body:"
+            cat /tmp/response.json
+            echo "::warning::Could not enable auto-merge due to permissions or repository policy. Manual review is required."
+
+            curl -s -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              -d '{"body":"🤖 **Dependabot Auto-Merge Status**\n\nThis PR meets the criteria for auto-merge but could not be automatically merged due to repository permissions.\n\n**Details:**\n- Update type: ${{ steps.metadata.outputs.update-type }}\n- Dependencies: ${{ steps.metadata.outputs.dependency-names }}\n- Previous version: ${{ steps.metadata.outputs.previous-version }}\n- New version: ${{ steps.metadata.outputs.new-version }}\n\nPlease review and merge manually if appropriate."}'
+          fi
+
+      - name: Comment on Major Version Updates
+        if: |
+          steps.check-labels.outputs.has-required-labels == 'true' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GH_TOKEN
+
+          curl -s -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
+
+      - name: Log Auto-Merge Decision
+        run: |
+          echo "Auto-merge decision for PR #${{ github.event.pull_request.number }}:"
+          echo "- Update type: ${{ steps.metadata.outputs.update-type }}"
+          echo "- Has required labels: ${{ steps.check-labels.outputs.has-required-labels }}"
+          echo "- Dependency: ${{ steps.metadata.outputs.dependency-names }}"
+
+          if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || \
+             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]] || \
+             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]]; then
+            if [[ "${{ steps.check-labels.outputs.has-required-labels }}" == "true" ]]; then
+              echo "✅ Auto-merge ENABLED"
+            else
+              echo "❌ Auto-merge DISABLED: Missing required labels"
+            fi
+          else
+            echo "❌ Auto-merge DISABLED: Major version update or unknown update type"
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,8 +36,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           # Check if the "go X.Y" directive in go.mod changed
-          GO_DIFF=$(gh pr diff ${{ github.event.pull_request.number }} -- go.mod | grep "^[+-]go [0-9]" || true)
+          GO_DIFF=$(gh pr diff ${{ github.event.pull_request.number }} --patch | awk '
+            /^diff --git a\/go\.mod b\/go\.mod$/ { in_go_mod=1; next }
+            /^diff --git / { in_go_mod=0 }
+            in_go_mod && /^[+-]go [0-9]/ { print }
+          ')
 
           if echo "$GO_DIFF" | grep -q "^-go "; then
             OLD_GO=$(echo "$GO_DIFF" | grep "^-go " | sed 's/^-go //')
@@ -58,7 +63,11 @@ jobs:
             "github.com/openshift-online/ocm-sdk-go"
             "k8s.io/client-go"
             "k8s.io/api"
+            "github.com/openshift/ocm-agent-operator"
             "github.com/openshift/api"
+            "sigs.k8s.io/controller-runtime"
+            "github.com/openshift-online/ocm-api-model/clientapi"
+            "k8s.io/klog/v2"
           )
           
           #For golang version changed, mark it critical

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,10 +30,36 @@ jobs:
         run: |
           echo "has-required-labels=true" >> $GITHUB_OUTPUT
           echo "✅ Dependabot PR detected - auto-merge enabled for safe updates"
+      
+      - name: Check Critical package updates
+        id: check-critical
+        if: |
+          contains(steps.metadata.outputs.dependency-names, 'github.com/openshift-online/ocm-sdk-go') ||
+          contains(steps.metadata.outputs.dependency-names, 'github.com/openshift/api') ||
+          contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
+        run: |
+          DEPENDENCY="${{ steps.metadata.outputs.dependency-names }}"
+          CRITICAL_PACKAGES=(
+            "github.com/openshift-online/ocm-sdk-go"
+            "k8s.io/client-go"
+            "k8s.io/api"
+            "github.com/openshift/api"
+          )
+          
+          for pkg in "${CRITICAL_PACKAGES[@]}"; do
+            if [[ "$DEPENDENCY" == *"$pkg"* ]]; then
+              echo "is_critical_update=true" >> $GITHUB_OUTPUT
+              echo "⚠️ Critical package detected: $pkg"
+              exit 0
+            fi
+          done
+
+          echo "is_critical_update=false" >> $GITHUB_OUTPUT
 
       - name: Enable Auto-Merge for Safe Updates
         if: |
-          steps.check-labels.outputs.has-required-labels == 'true' && (
+          steps.check-labels.outputs.has-required-labels == 'true' && 
+          steps.check-critical.outputs.is_critical_update == 'false' && (
             steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
             steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
             steps.metadata.outputs.update-type == 'version-update:semver-digest'
@@ -88,6 +114,7 @@ jobs:
       - name: Comment on Major Version Updates
         if: |
           steps.check-labels.outputs.has-required-labels == 'true' &&
+          steps.check-critical.outputs.is_critical_update == 'true' &&
           steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
           GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
@@ -97,23 +124,25 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
+            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update or critical dependency update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
 
       - name: Log Auto-Merge Decision
         run: |
           echo "Auto-merge decision for PR #${{ github.event.pull_request.number }}:"
           echo "- Update type: ${{ steps.metadata.outputs.update-type }}"
           echo "- Has required labels: ${{ steps.check-labels.outputs.has-required-labels }}"
+          echo "- Is critical component: ${{ steps.check-critical.outputs.is_critical_update }}"
           echo "- Dependency: ${{ steps.metadata.outputs.dependency-names }}"
 
           if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || \
              [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]] || \
-             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]]; then
+             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]] || \
+             [[ "${{ steps.check-critical.outputs.is_critical_update }}" == "false" ]]; then
             if [[ "${{ steps.check-labels.outputs.has-required-labels }}" == "true" ]]; then
               echo "✅ Auto-merge ENABLED"
             else
               echo "❌ Auto-merge DISABLED: Missing required labels"
             fi
           else
-            echo "❌ Auto-merge DISABLED: Major version update or unknown update type"
+            echo "❌ Auto-merge DISABLED: Major version update or critical component update or unknown update type"
           fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,19 +30,44 @@ jobs:
         run: |
           echo "has-required-labels=true" >> $GITHUB_OUTPUT
           echo "✅ Dependabot PR detected - auto-merge enabled for safe updates"
-      
+
+      - name: Check for Go version bump
+        id: check-go-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if the "go X.Y" directive in go.mod changed
+          GO_DIFF=$(gh pr diff ${{ github.event.pull_request.number }} -- go.mod | grep "^[+-]go [0-9]" || true)
+
+          if echo "$GO_DIFF" | grep -q "^-go "; then
+            OLD_GO=$(echo "$GO_DIFF" | grep "^-go " | sed 's/^-go //')
+            NEW_GO=$(echo "$GO_DIFF" | grep "^+go " | sed 's/^+go //')
+
+            echo "go-version-bumped=true" >> $GITHUB_OUTPUT
+            echo "⚠️ Go version bump detected: $OLD_GO → $NEW_GO"
+          else
+            echo "go-version-bumped=false" >> $GITHUB_OUTPUT
+            echo "✅ No Go version change detected"
+          fi
+
       - name: Check Critical package updates
         id: check-critical
         run: |
           DEPENDENCY="${{ steps.metadata.outputs.dependency-names }}"
           CRITICAL_PACKAGES=(
-            "go"
             "github.com/openshift-online/ocm-sdk-go"
             "k8s.io/client-go"
             "k8s.io/api"
             "github.com/openshift/api"
           )
           
+          #For golang version changed, mark it critical
+          if [[ "${{ steps.check-go-version.outputs.go-version-bumped }}" == "true" ]]; then
+            echo "is_critical_update=true" >> $GITHUB_OUTPUT
+            echo "⚠️ Golang version changed"
+            exit 0
+          fi
+
           for pkg in "${CRITICAL_PACKAGES[@]}"; do
             if [[ "$DEPENDENCY" == *"$pkg"* ]]; then
               echo "is_critical_update=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     # Only run for Dependabot PRs
-    if: github.actor == 'dependabot[bot]' && github.repository == '--add-gomod'
+    if: github.actor == 'dependabot[bot]' && github.repository == 'openshift/ocm-agent'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,13 +33,10 @@ jobs:
       
       - name: Check Critical package updates
         id: check-critical
-        if: |
-          contains(steps.metadata.outputs.dependency-names, 'github.com/openshift-online/ocm-sdk-go') ||
-          contains(steps.metadata.outputs.dependency-names, 'github.com/openshift/api') ||
-          contains(steps.metadata.outputs.dependency-names, 'k8s.io/api')
         run: |
           DEPENDENCY="${{ steps.metadata.outputs.dependency-names }}"
           CRITICAL_PACKAGES=(
+            "go"
             "github.com/openshift-online/ocm-sdk-go"
             "k8s.io/client-go"
             "k8s.io/api"
@@ -111,10 +108,23 @@ jobs:
               -d '{"body":"🤖 **Dependabot Auto-Merge Status**\n\nThis PR meets the criteria for auto-merge but could not be automatically merged due to repository permissions.\n\n**Details:**\n- Update type: ${{ steps.metadata.outputs.update-type }}\n- Dependencies: ${{ steps.metadata.outputs.dependency-names }}\n- Previous version: ${{ steps.metadata.outputs.previous-version }}\n- New version: ${{ steps.metadata.outputs.new-version }}\n\nPlease review and merge manually if appropriate."}'
           fi
 
+      - name: Comment on Critical Dependency Version Updates
+        if: |
+          steps.check-labels.outputs.has-required-labels == 'true' && 
+          steps.check-critical.outputs.is_critical_update == 'true'
+        run: |
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GH_TOKEN
+
+          curl -s -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            -d '{"body":"🚨 **Critical Dependency Version Update Detected** 🚨\n\nThis PR contains a critical dependency package version update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
+
       - name: Comment on Major Version Updates
         if: |
-          steps.check-labels.outputs.has-required-labels == 'true' &&
-          steps.check-critical.outputs.is_critical_update == 'true' &&
+          steps.check-labels.outputs.has-required-labels == 'true' && 
           steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
           GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
@@ -124,7 +134,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update or critical dependency update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
+            -d '{"body":"🚨 **Major Version Update Detected** 🚨\n\nThis PR contains a major version update that requires manual review:\n- **Dependency:** ${{ steps.metadata.outputs.dependency-names }}\n- **Previous version:** ${{ steps.metadata.outputs.previous-version }}\n- **New version:** ${{ steps.metadata.outputs.new-version }}\n\nPlease review the changelog and breaking changes before merging.\n\nAuto-merge has been **disabled** for this PR."}'
 
       - name: Log Auto-Merge Decision
         run: |
@@ -134,9 +144,9 @@ jobs:
           echo "- Is critical component: ${{ steps.check-critical.outputs.is_critical_update }}"
           echo "- Dependency: ${{ steps.metadata.outputs.dependency-names }}"
 
-          if [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || \
-             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]] || \
-             [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]] || \
+          if ( [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || \
+               [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-minor" ]] || \
+               [[ "${{ steps.metadata.outputs.update-type }}" == "version-update:semver-digest" ]] ) && \
              [[ "${{ steps.check-critical.outputs.is_critical_update }}" == "false" ]]; then
             if [[ "${{ steps.check-labels.outputs.has-required-labels }}" == "true" ]]; then
               echo "✅ Auto-merge ENABLED"


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation/test/refactor)_


### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured Dependabot to update Go modules weekly and group Kubernetes, OpenShift, and Prometheus updates.
  * Added scheduled checks to validate branch-protection and Dependabot configuration.

* **New Features**
  * Added an automated Dependabot PR auto-merge workflow: non-critical patch/minor/digest updates attempt auto-merge; critical packages, major bumps, and Go version bumps require manual review and get explanatory comments.

* **Bug Fixes**
  * Fixed newline handling in the Dependabot ignore entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->