### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+- bmeng
+- xiaoyu74
+- typeid
+- hectorakemp
+- srep-functional-team-hulk
+approvers:
+- tkong-redhat
+- srep-functional-leads
+- srep-team-leads


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.